### PR TITLE
[Chore] Swagger(SpringDoc OpenAPI) 초기 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
 	// OAuth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// Swagger (SpringDoc OpenAPI)
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gong/modu/config/SecurityConfig.java
+++ b/src/main/java/com/gong/modu/config/SecurityConfig.java
@@ -15,8 +15,13 @@ public class SecurityConfig {
                 // CSRF 비활성화
                 .csrf(csrf -> csrf.disable())
 
-                // 모든 요청 일단 허용함
+                // 모든 요청 일단 허용함 (Swagger UI 포함)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
                         .anyRequest().permitAll()
                 )
 

--- a/src/main/java/com/gong/modu/config/SwaggerConfig.java
+++ b/src/main/java/com/gong/modu/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.gong.modu.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String BEARER_AUTH = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Modu API")
+                        .description("Modu 서비스 REST API 명세서")
+                        .version("v1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH))
+                .components(new Components()
+                        .addSecuritySchemes(BEARER_AUTH, new SecurityScheme()
+                                .name(BEARER_AUTH)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
- Swagger UI 초기 세팅
- build.gradle 의존성 추가
- SwaggerConfig: OpenAPI 빈 생성, 프로젝트 기본 정보, JWT Bearer 인증 스키마 등록
- SecurityConfig: Swagger UI 접근 경로 명시적 허용                                                
- 접속 주소: `http://localhost:8080/swagger-ui/index.html`
> 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
