### PR TITLE
feat: 공모주 외부 데이터 수집을 위한 DART·KIS client와 sync service 추가

### DIFF
--- a/src/main/java/com/gong/modu/config/SchedulingConfig.java
+++ b/src/main/java/com/gong/modu/config/SchedulingConfig.java
@@ -1,4 +1,10 @@
 package com.gong.modu.config;
 
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+// Spring의 @Scheduled 기능을 활성화하는 설정 클래스
+@Configuration
+@EnableScheduling
 public class SchedulingConfig {
 }

--- a/src/main/java/com/gong/modu/domain/dto/dart/DartCompanyResponse.java
+++ b/src/main/java/com/gong/modu/domain/dto/dart/DartCompanyResponse.java
@@ -1,5 +1,6 @@
 package com.gong.modu.domain.dto.dart;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,21 +11,54 @@ import lombok.NoArgsConstructor;
 public class DartCompanyResponse {
     private String status; // DART 응답 상태 코드 (정상: 000)
     private String message;
+
+    @JsonProperty("corp_code")
     private String corpCode; // DART 기업 고유번호
+
+    @JsonProperty("corp_name")
     private String corpName;
+
     private String corpNameEng;
+
+    @JsonProperty("stock_name")
     private String stockName; // 종목명
+
+    @JsonProperty("stock_code")
     private String stockCode; // 종목코드
+
+    @JsonProperty("ceo_nm")
     private String ceoNm;
+
+    @JsonProperty("corp_cls")
     private String corpCls; // 법인 구분 (Y, K, N, E)
+
+    @JsonProperty("jurir_no")
     private String jurirNo;
+
+    @JsonProperty("bizr_no")
     private String bizrNo;
+
+    @JsonProperty("adres")
     private String adres;
+
+    @JsonProperty("hm_url")
     private String hmUrl;
+
+    @JsonProperty("ir_url")
     private String irUrl;
+
+    @JsonProperty("phn_no")
     private String phnNo;
+
+    @JsonProperty("fax_no")
     private String faxNo;
+
+    @JsonProperty("induty_code")
     private String indutyCode;  // 업종 코드
+
+    @JsonProperty("est_dt")
     private String estDt; // 설립일
+
+    @JsonProperty("acc_mt")
     private String accMt;
 }

--- a/src/main/java/com/gong/modu/domain/dto/dart/DartDisclosureSearchResponse.java
+++ b/src/main/java/com/gong/modu/domain/dto/dart/DartDisclosureSearchResponse.java
@@ -1,5 +1,6 @@
 package com.gong.modu.domain.dto.dart;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,24 +14,49 @@ public class DartDisclosureSearchResponse {
 
     private String status; // DART 응답 상태 코드 (정상: 000)
     private String message;
+
+    @JsonProperty("page_no")
     private Integer pageNo; // 현재 페이지 번호
+
+    @JsonProperty("page_count")
     private Integer pageCount; // 한 페이지당 조회 개수
+
+    @JsonProperty("total_count")
     private Integer totalCount; // 전체 검색 결과 개수
+
+    @JsonProperty("total_page")
     private Integer totalPage; // 전체 페이지 수
+
     private List<Item> list;  // 실제 공시 목록 (각 item 한 건이 공시 한 건)
 
     // 공시검색 결과의 개별 공시 항목 DTO
     @Getter
     @NoArgsConstructor
     public static class Item {
+        @JsonProperty("corp_code")
         private String corpCode; // DART 기업 고유번호
+
+        @JsonProperty("corp_name")
         private String corpName; // 기업명
+
+        @JsonProperty("stock_code")
         private String stockCode; // 종목코드 (상장사가 아닌 경우 null)
+
+        @JsonProperty("corp_cls")
         private String corpCls; // 법인 구분 (Y: 유가증권, K: 코스닥, N: 코넥스, E: 기타)
+
+        @JsonProperty("report_nm")
         private String reportNm; // 공시 보고서명
+
+        @JsonProperty("rcept_no")
         private String rceptNo; // DART 공시 접수번호
+
+        @JsonProperty("flr_nm")
         private String flrNm; // 제출인명
+
+        @JsonProperty("rcept_dt")
         private String rceptDt; // 접수일자
+
         private String rm; // 비고
     }
 }

--- a/src/main/java/com/gong/modu/domain/dto/dart/DartEquitySecuritiesReportResponse.java
+++ b/src/main/java/com/gong/modu/domain/dto/dart/DartEquitySecuritiesReportResponse.java
@@ -1,5 +1,6 @@
 package com.gong.modu.domain.dto.dart;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,10 +21,18 @@ public class DartEquitySecuritiesReportResponse {
     @NoArgsConstructor
     public static class Item {
 
+        @JsonProperty("rcept_no")
         private String rceptNo; // 공시 접수번호
+
+        @JsonProperty("corp_cls")
         private String corpCls; // 법인 구분 (Y/K/N/E)
+
+        @JsonProperty("corp_code")
         private String corpCode; // DART 기업 고유번호
+
+        @JsonProperty("corp_name")
         private String corpName; // 기업명
+
         private String sbd; // 청약기일
         private String pymd; // 납입기일
         private String sband; // 청약공고일

--- a/src/main/java/com/gong/modu/domain/dto/dart/DartFinancialStatementResponse.java
+++ b/src/main/java/com/gong/modu/domain/dto/dart/DartFinancialStatementResponse.java
@@ -1,5 +1,6 @@
 package com.gong.modu.domain.dto.dart;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,21 +19,51 @@ public class DartFinancialStatementResponse {
     @Getter
     @NoArgsConstructor
     public static class Item {
+        @JsonProperty("rcept_no")
         private String rceptNo; // 공시 접수번호
+
+        @JsonProperty("reprt_code")
         private String reprtCode; // 보고서 코드 (11011: 사업보고서, 11012: 반기보고서, 11013: 1분기보고서, 11014: 3분기보고서)
+
+        @JsonProperty("bsns_year")
         private String bsnsYear; // 사업연도
+
+        @JsonProperty("corp_code")
         private String corpCode; // DART 기업 고유번호입
+
+        @JsonProperty("sj_div")
         private String sjDiv; // 재무제표 구분 코드
+
+        @JsonProperty("sj_nm")
         private String sjNm; // 재무제표 구분명
+
+        @JsonProperty("account_id")
         private String accountId; // 계정 ID
+
+        @JsonProperty("account_nm")
         private String accountNm; // 계정명
+
+        @JsonProperty("account_detail")
         private String accountDetail; // 계정 상세
+
+        @JsonProperty("thstrm_nm")
         private String thstrmNm; // 당기명
+
+        @JsonProperty("thstrm_amount")
         private String thstrmAmount; // 당기 금액
+
+        @JsonProperty("frmtrm_nm")
         private String frmtrmNm; // 전기명
+
+        @JsonProperty("frmtrm_amount")
         private String frmtrmAmount; // 전기 금액
+
+        @JsonProperty("bfefrmtrm_nm")
         private String bfefrmtrmNm; // 전전기명
+
+        @JsonProperty("bfefrmtrm_amount")
         private String bfefrmtrmAmount; // 전전기 금액
+
         private String ord; // 정렬 순서
         private String currency; // 통화 단위
     }

--- a/src/main/java/com/gong/modu/domain/entity/ipo/IpoDisclosureReport.java
+++ b/src/main/java/com/gong/modu/domain/entity/ipo/IpoDisclosureReport.java
@@ -101,4 +101,9 @@ public class IpoDisclosureReport extends BaseTimeEntity {
         this.riskSummary = riskSummary;
         this.summaryVersion = summaryVersion;
     }
+
+    // 공시명 갱신 메서드
+    public void updateReportInfo(String reportName) {
+        this.reportName = reportName;
+    }
 }

--- a/src/main/java/com/gong/modu/domain/entity/ipo/IpoEvent.java
+++ b/src/main/java/com/gong/modu/domain/entity/ipo/IpoEvent.java
@@ -121,7 +121,35 @@ public class IpoEvent extends BaseTimeEntity {
         this.lockupExpiryDate = lockupExpiryDate;
     }
 
+    // DART 주요정보 API에서 확실하게 제공되는 일정만 갱신하는 메서드
+    public void updateDartSchedule(
+            LocalDate subscriptionStartDate,
+            LocalDate subscriptionEndDate,
+            LocalDate paymentDate,
+            LocalDate allocationDate
+    ) {
+        this.subscriptionStartDate = subscriptionStartDate;
+        this.subscriptionEndDate = subscriptionEndDate;
+        this.paymentDate = paymentDate;
+        this.allocationDate = allocationDate;
+    }
+
     public void updateStatus(IpoEventStatus status) { // 공모이벤트 진행 상태 변경 메서드
         this.status = status; // UPCOMING, ONGOING, CLOSED, LISTED 중 하나로 갱신
+    }
+
+    // 공모 이벤트 기본 정보 갱신 메서드
+    public void updateBasicInfo(
+            String rceptNo,
+            String eventName,
+            IpoEventType eventType,
+            MarketType marketType,
+            String mainReportRceptNo
+    ) {
+        this.rceptNo = rceptNo;
+        this.eventName = eventName;
+        this.eventType = eventType;
+        this.marketType = marketType;
+        this.mainReportRceptNo = mainReportRceptNo;
     }
 }

--- a/src/main/java/com/gong/modu/domain/entity/ipo/IpoOffering.java
+++ b/src/main/java/com/gong/modu/domain/entity/ipo/IpoOffering.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.springframework.cglib.core.Local;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -106,5 +107,14 @@ public class IpoOffering extends BaseTimeEntity {
         this.offerMethod = offerMethod;
         this.equalAllocationShares = equalAllocationShares;
         this.generalAllocationShares = generalAllocationShares;
+    }
+
+    // 청약 공고일, 배정 기준일 갱신 메서드
+    public void updateOfferingDates(
+            LocalDate subscriptionNoticeDate,
+            LocalDate allocationBaseDate
+    ) {
+        this.subscriptionNoticeDate = subscriptionNoticeDate;
+        this.allocationBaseDate = allocationBaseDate;
     }
 }

--- a/src/main/java/com/gong/modu/exception/ErrorCode.java
+++ b/src/main/java/com/gong/modu/exception/ErrorCode.java
@@ -53,8 +53,11 @@ public enum ErrorCode {
     // KIS 접근 토큰 발급 실패 시 사용하는 에러 (KIS는 주가 API 호출 전에 access token을 발급받아야 하므로 토큰 발급 실패는 일반 KIS API 조회 실패와 분리함)
     KIS_TOKEN_ERROR(HttpStatus.BAD_GATEWAY, "KIS 접근 토큰 발급 중 오류가 발생했습니다."),
     // 외부 API 호출은 성공했지만 response body가 null인 경우 사용 (HTTP 상태는 정상이어도 실제 응답 객체가 비어 있으면 이후 DTO 접근에서 NullPointerException 발생할 수 있음)
-    EXTERNAL_API_EMPTY_RESPONSE(HttpStatus.BAD_GATEWAY, "외부 API 응답이 비어 있습니다.");
-
+    EXTERNAL_API_EMPTY_RESPONSE(HttpStatus.BAD_GATEWAY, "외부 API 응답이 비어 있습니다."),
+    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "기업 정보를 찾을 수 없습니다."),
+    IPO_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "공모주 정보를 찾을 수 없습니다."),
+    FINANCIAL_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "기업 재무 정보를 찾을 수 없습니다."),
+    STOCK_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "종목코드가 없어 주가를 조회할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/gong/modu/repository/ipo/CompanyRepository.java
+++ b/src/main/java/com/gong/modu/repository/ipo/CompanyRepository.java
@@ -16,6 +16,9 @@ public interface CompanyRepository extends JpaRepository<Company, Long> {
     // 종목코드로 조회
     Optional<Company> findByStockCode(String stockCode);
 
+    // 종목코드가 존재하는 기업만 조회
+    List<Company> findByStockCodeIsNotNull();
+
     // 기업명 포함 검색
     List<Company> findByCorpNameContaining(String keyword);
 

--- a/src/main/java/com/gong/modu/scheduler/ExternalDataScheduler.java
+++ b/src/main/java/com/gong/modu/scheduler/ExternalDataScheduler.java
@@ -1,4 +1,55 @@
 package com.gong.modu.scheduler;
 
+import com.gong.modu.domain.entity.ipo.Company;
+import com.gong.modu.repository.ipo.CompanyRepository;
+import com.gong.modu.service.pipeline.KisStockPriceSyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j // 배치 시작/종료/실패 로그를 위함
+@Component
+@RequiredArgsConstructor
+// 외부 API 데이터 동기화를 주기적으로 실행하는 스케줄러 클래스
 public class ExternalDataScheduler {
+    private static final DateTimeFormatter BASIC_DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final CompanyRepository companyRepository;
+    private final KisStockPriceSyncService kisStockPriceSyncService; // 실제 KIS 주가 동기화 로직을 실행할 서비스
+
+
+    // 상장 기업들의 KIS 주가 뎅ㅣ터를 동기화하는 스케줄러 메서드
+    // 주식 장 마감 후 데이터를 가져오기 위해 오후 6시로 설정
+    @Scheduled(cron = "0 0 18 * * MON-FRI")
+    public void syncListedCompanyPrices() {
+        log.info("[Scheduler] KIS 상장 기업 주가 동기화 시작"); // 배치 시작 로그
+
+        List<Company> companies = companyRepository.findByStockCodeIsNotNull();
+        LocalDate today = LocalDate.now();
+
+        String endDate = today.format(BASIC_DATE); // 오늘 날짜를 yyyyMMdd 문자열로 변환
+        String startDate = today.minusDays(7).format(BASIC_DATE); // 오늘로부터 7일 전 날짜 변환 -> 최근 7일치 일봉 데이터 보강
+
+        for (Company company : companies) {
+            try { // 기업별 try
+                kisStockPriceSyncService.syncCurrentPrice(company.getId()); // 해당 기업의 현재가 동기화
+                kisStockPriceSyncService.syncDailyPrices(company.getId(), startDate, endDate); // 해당 기업의 최근 7일 일봉 데이터 동기화
+            } catch (Exception e) { // 특정 기업의 주가 동기화에 실패했을 경우
+                // 어떤 기업에서 실패했는지 companyId와 stockCode를 로그로 남김
+                log.warn(
+                        "[Scheduler] 주가 동기화 실패: companyId={}, stockCode={}",
+                        company.getId(),
+                        company.getStockCode(),
+                        e // stack trace 출력
+                );
+            }
+        }
+
+        log.info("[Scheduler] KIS 상장 기업 주가 동기화 종료"); // 배치 종료 로그
+    }
 }

--- a/src/main/java/com/gong/modu/service/pipeline/DartCompanySyncService.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DartCompanySyncService.java
@@ -1,4 +1,98 @@
 package com.gong.modu.service.pipeline;
 
+import com.gong.modu.client.DartApiClient;
+import com.gong.modu.domain.dto.dart.DartCompanyResponse;
+import com.gong.modu.domain.entity.ipo.Company;
+import com.gong.modu.domain.enums.ipo.CorpClass;
+import com.gong.modu.domain.enums.ipo.MarketType;
+import com.gong.modu.exception.CustomException;
+import com.gong.modu.exception.ErrorCode;
+import com.gong.modu.repository.ipo.CompanyRepository;
+import com.gong.modu.util.ExternalDateParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+// DART 기업개황 API에서 기업 정보를 가져와 companies 테이블에 저장하거나 갱신하는 클래스
 public class DartCompanySyncService {
+
+    private final DartApiClient dartApiClient;
+    private final CompanyRepository companyRepository;
+
+    @Transactional
+    // 특정 Dart 기업 고유번호를 기준으로 기업 정보를 동기화하는 메서드
+    public Company syncCompany(String corpCode) {
+
+        DartCompanyResponse response = dartApiClient.getCompany(corpCode); // DART 기업개황 API 호출
+
+        validateCompanyResponse(response);
+
+        CorpClass corpClass = parseCorpClass(response.getCorpCls());
+        MarketType marketType = mapMarketType(corpClass);
+        LocalDate establishedAt = ExternalDateParser.parseFlexibleDate(response.getEstDt());
+
+        return companyRepository.findByCorpCode(response.getCorpCode())
+                .map(existing -> {
+                    existing.updateBasicInfo( // 기존 Company 기본 정보를 최신 DART 응답값으로 갱신
+                            response.getCorpName(),
+                            response.getCorpNameEng(),
+                            response.getStockCode(),
+                            corpClass,
+                            response.getStockName(),
+                            marketType,
+                            response.getIndutyCode(),
+                            establishedAt
+                    );
+
+                    return existing; // 갱신된 기존 엔티티 반환
+                }).orElseGet(() -> companyRepository.save( // Optional 안에 값이 없을 경우
+                        Company.builder()
+                                .corpCode(response.getCorpCode())
+                                .corpName(response.getCorpName())
+                                .corpNameEng(response.getCorpNameEng())
+                                .stockCode(response.getStockCode())
+                                .corpClass(corpClass)
+                                .stockName(response.getStockName())
+                                .marketType(marketType)
+                                .industryCode(response.getIndutyCode())
+                                .establishedAt(establishedAt)
+                                .build()
+                ));
+    }
+
+    private CorpClass parseCorpClass(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        try {
+            return CorpClass.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private MarketType mapMarketType(CorpClass corpClass) {
+        if (corpClass == null) {
+            return null;
+        }
+
+        return switch (corpClass) {
+            case Y -> MarketType.KOSPI;
+            case K -> MarketType.KOSDAQ;
+            case N -> MarketType.KONEX;
+            case E -> null;
+        };
+    }
+
+    private void validateCompanyResponse(DartCompanyResponse response) {
+        if (response.getCorpCode() == null || response.getCorpCode().isBlank()
+                || response.getCorpName() == null || response.getCorpName().isBlank()) {
+            throw new CustomException(ErrorCode.DART_API_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/gong/modu/service/pipeline/DartFinancialSyncService.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DartFinancialSyncService.java
@@ -1,4 +1,124 @@
 package com.gong.modu.service.pipeline;
 
+import com.gong.modu.client.DartApiClient;
+import com.gong.modu.domain.dto.dart.DartFinancialStatementResponse;
+import com.gong.modu.domain.entity.ipo.Company;
+import com.gong.modu.domain.entity.ipo.CompanyFinancialHighlight;
+import com.gong.modu.domain.enums.ipo.FinancialStatementType;
+import com.gong.modu.domain.enums.ipo.ReportCode;
+import com.gong.modu.exception.CustomException;
+import com.gong.modu.exception.ErrorCode;
+import com.gong.modu.repository.ipo.CompanyFinancialHighlightRepository;
+import com.gong.modu.repository.ipo.CompanyRepository;
+import com.gong.modu.util.ExternalNumberParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+// DART 재무제표 API 응답을 company_financial_highlights 테이블에 저장/갱신하는 서비스
 public class DartFinancialSyncService {
+
+    private final DartApiClient dartApiClient;
+    private final CompanyRepository companyRepository;
+    private final CompanyFinancialHighlightRepository financialHighlightRepository;
+
+    @Transactional
+    // 특정 기업의 특정 연도/보고서/재무제표 구분에 해당하는 재무 하이라이트를 동기화하는 메서드
+    public CompanyFinancialHighlight syncFinancialHighlight(
+            Long companyId,
+            String businessYear,
+            ReportCode reportCode,
+            FinancialStatementType financialStatementType
+    ) {
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
+
+        // DART 단일회사 전체 재무제표 API 호출
+        DartFinancialStatementResponse response = dartApiClient.getFinancialStatements(
+                company.getCorpCode(),
+                businessYear,
+                reportCode.getCode(),
+                financialStatementType.name()
+        );
+
+        // DART 재무제표 응답의 실제 계정과목 목록
+        List<DartFinancialStatementResponse.Item> items = response.getList();
+
+        Long revenue = findAmount(items, "매출액");
+        Long operatingProfit = findAmount(items, "영업이익");
+        Long netIncome = findAmount(items, "당기순이익");
+        Long totalAssets = findAmount(items, "자산총계");
+        Long totalLiabilities = findAmount(items, "부채총계");
+        Long totalEquity = findAmount(items, "자본총계");
+        String currency = findCurrency(items);
+
+        return financialHighlightRepository
+                .findByCompanyIdAndBsnsYearAndReportCodeAndFinancialStatementType(
+                        companyId,
+                        businessYear,
+                        reportCode,
+                        financialStatementType
+                ) // 같은 구분의 데이터가 이미 있는지 검사
+                .map(existing -> {
+                    existing.updateFinancials( // 최신 응답값으로 갱신
+                            revenue,
+                            operatingProfit,
+                            netIncome,
+                            totalAssets,
+                            totalLiabilities,
+                            totalEquity,
+                            currency
+                    );
+
+                    return existing; // 갱신된 기존 엔티티 반환
+
+                }).orElseGet(() -> financialHighlightRepository.save(
+                        CompanyFinancialHighlight.builder()
+                                .company(company)
+                                .bsnsYear(businessYear)
+                                .reportCode(reportCode)
+                                .financialStatementType(financialStatementType)
+                                .revenue(revenue)
+                                .operatingProfit(operatingProfit)
+                                .netIncome(netIncome)
+                                .totalAssets(totalAssets)
+                                .totalLiabilities(totalLiabilities)
+                                .totalEquity(totalEquity)
+                                .currency(currency)
+                                .build()
+                ));
+
+    }
+
+    // DART 재무제표 항목 목록에서 특정 계정명에 해당하는 금액을 찾는 메서드
+    private Long findAmount(List<DartFinancialStatementResponse.Item> items, String accountNameKeyword) {
+        if (items == null || items.isEmpty()) {
+            return null;
+        }
+
+        return items.stream()
+                .filter(item -> item.getAccountNm() != null)
+                .filter(item -> item.getAccountNm().contains(accountNameKeyword))
+                .map(DartFinancialStatementResponse.Item::getThstrmAmount) // 찾은 항목에서 당기 금액 문자열만 꺼냄
+                .map(ExternalNumberParser::toLong)
+                .findFirst()
+                .orElse(null);
+    }
+
+    // 재무제표 항목 목록에서 통화 단위를 찾는 메서드
+    private String findCurrency(List<DartFinancialStatementResponse.Item> items) {
+        if (items == null || items.isEmpty()) {
+            return null;
+        }
+
+        return items.stream()
+                .map(DartFinancialStatementResponse.Item::getCurrency)
+                .filter(currency -> currency != null && !currency.isBlank())
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/src/main/java/com/gong/modu/service/pipeline/DartIpoSyncService.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DartIpoSyncService.java
@@ -1,4 +1,241 @@
 package com.gong.modu.service.pipeline;
 
+import com.gong.modu.client.DartApiClient;
+import com.gong.modu.domain.dto.dart.DartDisclosureSearchResponse;
+import com.gong.modu.domain.dto.dart.DartEquitySecuritiesReportResponse;
+import com.gong.modu.domain.entity.ipo.*;
+import com.gong.modu.domain.enums.ipo.BrokerRole;
+import com.gong.modu.domain.enums.ipo.IpoEventStatus;
+import com.gong.modu.domain.enums.ipo.IpoEventType;
+import com.gong.modu.exception.CustomException;
+import com.gong.modu.exception.ErrorCode;
+import com.gong.modu.repository.ipo.*;
+import com.gong.modu.util.ExternalDateParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+// 공모주 관련 DART 데이터를 DB에 저장하는 Service
+// DART 공시검색 API와 지분증권 주요신고서 주요정보 API를 이용하여 ipo_events, ipo_offerings, brokers, ipo_event_brokers, ipo_disclosure_reports를 채우는 서비스
 public class DartIpoSyncService {
+
+    private final DartApiClient dartApiClient;
+    private final CompanyRepository companyRepository;
+    private final IpoEventRepository ipoEventRepository;
+    private final IpoOfferingRepository ipoOfferingRepository;
+    private final IpoEventBrokerRepository ipoEventBrokerRepository;
+    private final BrokerRepository brokerRepository;
+    private final IpoDisclosureReportRepository disclosureReportRepository;
+
+    @Transactional
+    // 특정 기업의 특정 기간 공모 관련 데이터를 동기화하는 메서드
+    public void syncIpoByCompany(String corpCode, String beginDate, String endDate){
+        Company company = companyRepository.findByCorpCode(corpCode) // corpCode로 기업을 조회
+                .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
+
+        // DART 공시검색 API 호출
+        // disclosureType -> null : 초기에는 전체 공시에서 reportNm 기준으로 증권신고서를 필터링하기 위함
+        DartDisclosureSearchResponse disclosureSearchResponse = dartApiClient.searchDisclosure(
+                beginDate,
+                endDate,
+                corpCode,
+                null,
+                1,
+                100
+        );
+
+        if (disclosureSearchResponse.getList() != null) {
+            disclosureSearchResponse.getList().stream()
+                    .filter(item -> item.getReportNm() != null)
+                    .filter(item -> item.getReportNm().contains("증권신고서")) // 보고서명에 증권신고서가 들어간 공시만 필터링
+                    .forEach(item -> upsertDisclosureReport(company, item)); // // 각 공시 항목을 ipo_disclosure_reports에 저장하거나 갱신
+        }
+
+        // DART 지분증권 증권신고서 주요정보 API 호출: 청약기일, 납입기일, 인수기관명 등의 구조화 데이터를 얻기 위해 사용
+        DartEquitySecuritiesReportResponse equityResponse =
+                dartApiClient.getEquitySecuritiesReport(corpCode, beginDate, endDate);
+
+        if (equityResponse.getList() == null) {
+            return; // 주요정보 목록이 없다면 더 처리할 데이터가 없으므로 메서드 종료
+        }
+
+        // 주요 정보 목록을 하나씩 순회
+        for (DartEquitySecuritiesReportResponse.Item item : equityResponse.getList()) {
+            upsertIpoCoreData(company, item); // 각 주요정보 항목을 바탕으로 ipo_events, ipo_offerings, broker 관련 데이터를 저장/갱신
+        }
+    }
+
+    // 공시 검색 결과 1건을 ipo_disclosure_reports에 저장하거나 갱신하는 메서드
+    private void upsertDisclosureReport(
+            Company company,
+            DartDisclosureSearchResponse.Item item
+    ) {
+        // 공시 접수번호를 기준으로 IpoEvent를 찾거나 새로 생성
+        // 공시 보고서를 특정 공모 이벤트에 연결되어야 하므로 먼저 IpoEvent가 필요함
+        IpoEvent ipoEvent = findOrCreateIpoEvent(
+                company, item.getRceptNo(), item.getReportNm()
+        );
+
+        disclosureReportRepository.findByIpoEventIdAndRceptNo(ipoEvent.getId(), item.getRceptNo())
+                .ifPresentOrElse(
+                        // 이미 존재하면 reportName만 최신값으로 갱신
+                        existing -> existing.updateReportInfo(item.getReportNm()),
+
+                        () -> disclosureReportRepository.save( // 없으면 새 IpoDisclosureReport 저장
+                                IpoDisclosureReport.builder()
+                                        .ipoEvent(ipoEvent)
+                                        .rceptNo(item.getRceptNo())
+                                        .reportName(item.getReportNm())
+                                        .build()
+                        )
+                );
+    }
+
+    // 지분증권 증권신고서 주요정보 응답 1건을 IPO 핵심 데이터로 저장/갱신하는 메서드
+    private void upsertIpoCoreData(
+            Company company,
+            DartEquitySecuritiesReportResponse.Item item
+    ) {
+        // 접수번호 기준으로 IpoEvent를 찾거나 생성
+        IpoEvent ipoEvent = findOrCreateIpoEvent(company, item.getRceptNo(), item.getCorpName());
+
+        // 청약기일 문자열에서 첫 번째 날짜를 시작일로 추출합
+        LocalDate subscriptionStart = ExternalDateParser.parseFirstDateFromRange(item.getSbd());
+
+        // 청약기일 문자열에서 마지막 날짜를 종료일로 추출
+        LocalDate subscriptionEnd = ExternalDateParser.parseLastDateFromRange(item.getSbd());
+
+        // 납입기일 문자열을 LocalDate로 변환
+        LocalDate paymentDate = ExternalDateParser.parseFlexibleDate(item.getPymd());
+
+        // 배정공고일 문자열을 LocalDate로 변환
+        LocalDate allocationDate = ExternalDateParser.parseFlexibleDate(item.getAsand());
+
+        // 공모 이벤트 일정 정보 갱신
+        // DART 주요정보 응답에서 수요예측일, 환불일, 상장일, 보호예수 해제일은 직접 얻지 못하므로 null로 처리 -> 해당 값은 원문 파싱이나 관리자 입력 필요
+        ipoEvent.updateDartSchedule(
+                subscriptionStart,
+                subscriptionEnd,
+                paymentDate,
+                allocationDate
+        );
+
+        // 청약 시작/종료일 기준으로 공모 상태를 계산하여 갱신
+        ipoEvent.updateStatus(determineStatus(subscriptionStart, subscriptionEnd, null));
+
+        // 청약공고일, 배정기준일 등 공모 조건 보조 정보를 저장/갱신
+        upsertOffering(ipoEvent, item);
+
+        // 인수기관 문자열을 바탕으로 증권사 정보를 저장/갱신
+        upsertBroker(ipoEvent, item.getUdtintnm());
+    }
+
+    // 접수번호를 기준으로 IpoEvent를 찾거나 새로 생성하는 메서드
+    private IpoEvent findOrCreateIpoEvent(
+            Company company,
+            String rceptNo,
+            String eventName
+    ) {
+        return ipoEventRepository.findByMainReportRceptNo(rceptNo) // 대표 공시 접수번호 기준으로 기존 공모 이벤트 조회
+                .orElseGet(() -> ipoEventRepository.save(
+                        IpoEvent.builder()
+                                .company(company)
+                                .rceptNo(rceptNo)
+                                .mainReportRceptNo(rceptNo)
+                                .eventName(eventName)
+                                .eventType(IpoEventType.IPO) // 공모 이벤트 유형을 일반 IPO로 기본 설정
+                                .marketType(company.getMarketType())
+                                .status(IpoEventStatus.UPCOMING) // 새로 만든 이벤트는 예정 상태로 기본 설정
+                                .build()
+                ));
+    }
+
+    // 지분증권 주요정보에서 얻은 일정성 공모 조건을 ipo_offerings에 저장/갱신하는 메서드
+    private void upsertOffering(
+            IpoEvent ipoEvent,
+            DartEquitySecuritiesReportResponse.Item item
+    ) {
+        LocalDate subscriptionNoticeDate = ExternalDateParser.parseFlexibleDate(item.getSband()); // 청약공고일 변환
+        LocalDate allocationBaseDate = ExternalDateParser.parseFlexibleDate(item.getAsstd()); // 배정기준일 변환
+        ipoOfferingRepository.findByIpoEventId(ipoEvent.getId())
+                .ifPresentOrElse(
+                        // 기존 레코드가 있으면 날짜 정보만 갱신
+                        existing -> existing.updateOfferingDates(subscriptionNoticeDate, allocationBaseDate),
+                        () -> ipoOfferingRepository.save(
+                                IpoOffering.builder()
+                                        .ipoEvent(ipoEvent)
+                                        .subscriptionNoticeDate(subscriptionNoticeDate)
+                                        .allocationBaseDate(allocationBaseDate)
+                                        .build()
+                        )
+                );
+    }
+
+    // 인수기관명 문자열을 Broker와 IpoEventBroker로 저장하는 메서드
+    private void upsertBroker(IpoEvent ipoEvent, String brokerNamesText) {
+        if (brokerNamesText == null || brokerNamesText.isBlank()) {
+            return; // 인수기관명이 없으면 저장할 증권사 정보가 없음
+        }
+
+        String[] brokerNames = brokerNamesText.split("[,/]");
+
+        for (String rawName : brokerNames) {
+            String brokerName = rawName.trim();
+
+            if (brokerName.isBlank()) {
+                continue;
+            }
+
+            Broker broker = brokerRepository.findByName(brokerName)
+                    .orElseGet(() -> brokerRepository.save(
+                            Broker.builder()
+                                    .name(brokerName)
+                                    .build()
+                    ));
+
+            boolean alreadyExists = ipoEventBrokerRepository
+                    .findByIpoEventId(ipoEvent.getId()) // 해당 공모 이벤트에 이미 연결된 증권사 목록을 가져옴
+                    .stream()
+                    .anyMatch(eventBroker -> brokerName.equals(eventBroker.getBrokerName()));
+
+            if (!alreadyExists) {
+                ipoEventBrokerRepository.save(
+                        IpoEventBroker.builder()
+                                .ipoEvent(ipoEvent)
+                                .broker(broker) // 정규화된 증권사 마스터
+                                .brokerName(brokerName) // 원문 또는 정제된 증권사명
+                                .role(BrokerRole.UNDERWRITER) // 초기 기본 역할은 인수회사로 설정
+                                .build()
+                );
+            }
+        }
+    }
+
+    // 청약일과 상장일을 기준으로 공모 이벤트 상태를 계산하는 내부 메서드
+    private IpoEventStatus determineStatus(
+            LocalDate subscriptionStart,
+            LocalDate subscriptionEnd,
+            LocalDate listingDate
+    ) {
+        LocalDate today = LocalDate.now(); // 오늘 날짜
+
+        if (listingDate != null && !listingDate.isAfter(today)) { // 상장일이 있고 상장일이 오늘 또는 과거라면 이미 상장된 상태
+            return IpoEventStatus.LISTED;
+        }
+
+        if (subscriptionStart != null && subscriptionEnd != null
+                && !today.isBefore(subscriptionStart)
+                && !today.isAfter(subscriptionEnd)) { // 오늘이 청약 시작일과 종료일 사이에 있으면 청약 진행중
+            return IpoEventStatus.ONGOING;
+        }
+
+        if (subscriptionEnd != null && subscriptionEnd.isBefore(today)) // 청약 종료일이 오늘보다 이전이면 청약은 마감된 상태
+            return IpoEventStatus.CLOSED;
+
+        return IpoEventStatus.UPCOMING; // 위 조건에 모두 해당하지 않으면 예정 상태
+    }
 }

--- a/src/main/java/com/gong/modu/service/pipeline/KisStockPriceSyncService.java
+++ b/src/main/java/com/gong/modu/service/pipeline/KisStockPriceSyncService.java
@@ -1,4 +1,153 @@
 package com.gong.modu.service.pipeline;
 
+import com.gong.modu.client.KisStockApiClient;
+import com.gong.modu.domain.dto.kis.KisCurrentPriceResponse;
+import com.gong.modu.domain.dto.kis.KisDailyPriceResponse;
+import com.gong.modu.domain.entity.ipo.Company;
+import com.gong.modu.domain.entity.ipo.StockPrice;
+import com.gong.modu.domain.enums.ipo.StockPriceSource;
+import com.gong.modu.exception.CustomException;
+import com.gong.modu.exception.ErrorCode;
+import com.gong.modu.repository.ipo.CompanyRepository;
+import com.gong.modu.repository.ipo.StockPriceRepository;
+import com.gong.modu.util.ExternalDateParser;
+import com.gong.modu.util.ExternalNumberParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+// KIS 주식 API 응답을 stock_prices 테이블에 저장/갱신하는 서비스
 public class KisStockPriceSyncService {
+
+    private final KisStockApiClient kisStockApiClient; // KIS 현재가/기간별 시세 API 호출 담당
+    private final CompanyRepository companyRepository;
+    private final StockPriceRepository stockPriceRepository;
+
+    @Transactional
+    // 특정 기업의 현재가를 KIS API에서 가져와 stock_price에 저장/갱신하는 메서드
+    public StockPrice syncCurrentPrice(Long companyId) {
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
+
+        if (company.getStockCode() == null || company.getStockCode().isBlank()) {
+            throw new CustomException(ErrorCode.STOCK_CODE_NOT_FOUND);
+        }
+
+        // KIS 현재가 API 호출
+        KisCurrentPriceResponse response = kisStockApiClient.getCurrentPrice(company.getStockCode());
+
+        // 실제 시세 데이터가 담긴 output 객체 꺼냄
+        KisCurrentPriceResponse.Output output = response.getOutput();
+
+        // 현재가 데이터는 오늘 날짜 기준으로 저장
+        LocalDate today = LocalDate.now();
+
+        BigDecimal currentPrice = ExternalNumberParser.toBigDecimal(output.getCurrentPrice()); // 현재가 변환
+        BigDecimal openPrice = ExternalNumberParser.toBigDecimal(output.getOpenPrice()); // 시가 변환
+        BigDecimal highPrice = ExternalNumberParser.toBigDecimal(output.getHighPrice()); // 고가 변환
+        BigDecimal lowPrice = ExternalNumberParser.toBigDecimal(output.getLowPrice()); // 저가 변환
+        Long volume = ExternalNumberParser.toLong(output.getAccumulatedVolume()); // 누적 거래량 변환
+
+        return stockPriceRepository.findByCompanyIdAndTradeDate(companyId, today)
+                .map(existing -> { // 오늘 날짜 레코드가 이미 존재한다면 기존 레코드 갱신
+                    existing.updatePrice(
+                            openPrice,
+                            highPrice,
+                            lowPrice,
+                            null, // 현재가 API에는 종가가 아직 확정되지 않았을 수 있으므로 closePrice는 null 처리
+                            currentPrice,
+                            volume,
+                            StockPriceSource.KIS
+                    );
+
+                    return existing;
+                })
+                .orElseGet(() -> stockPriceRepository.save( // 오늘 날짜 레코드가 없다면 새로 저장
+                        StockPrice.builder()
+                                .company(company)
+                                .tradeDate(today)
+                                .openPrice(openPrice)
+                                .highPrice(highPrice)
+                                .lowPrice(lowPrice)
+                                .currentPrice(currentPrice)
+                                .volume(volume)
+                                .source(StockPriceSource.KIS)
+                                .build()
+                ));
+    }
+
+    @Transactional
+    // 특정 기업의 기간별 일봉 시세를 KIS에서 가져와 저장
+    public void syncDailyPrices(Long companyId, String startDate, String endDate) {
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
+
+        // 종목코드가 없을 시 일별 시세 조회 불가능
+        if (company.getStockCode() == null || company.getStockCode().isBlank()) {
+            return; // 배치 작업에서는 하나의 기업 때문에 전체 스케줄러가 죽지 않도록 조용히 종료
+        }
+
+        // KIS 기간별 시세 API를 호출
+        // D => 일봉 데이터
+        KisDailyPriceResponse response = kisStockApiClient.getDailyPrices(
+                company.getStockCode(),
+                startDate,
+                endDate,
+                "D"
+        );
+
+        if (response.getDailyItems() ==  null) { // 응답에 일별 데이터가 없으면 저장할게 없음
+            return;
+        }
+
+        for (KisDailyPriceResponse.DailyItem item : response.getDailyItems()) {
+            upsertDailyPrice(company, item); // 각 일별 시세 목록을 저장 또는 갱신
+        }
+    }
+
+    // 일별 시세 한 건을 StockPrice 엔티티로 저장/갱신하는 메서드
+    private void upsertDailyPrice(Company company, KisDailyPriceResponse.DailyItem item) {
+        LocalDate tradeDate = ExternalDateParser.parseBasicDate(item.getTradeDate());
+
+        if (tradeDate == null) // 거래일을 파싱하지 못하면 주가 데이터 기준일이 없으므로 저장 불가
+            return; // 메서드 종료
+
+        BigDecimal openPrice = ExternalNumberParser.toBigDecimal(item.getOpenPrice()); // 시가 변환
+        BigDecimal highPrice = ExternalNumberParser.toBigDecimal(item.getHighPrice()); // 고가 변환
+        BigDecimal lowPrice = ExternalNumberParser.toBigDecimal(item.getLowPrice()); // 저가 변환
+        BigDecimal closePrice = ExternalNumberParser.toBigDecimal(item.getClosePrice()); // 종가 변환
+        Long volume = ExternalNumberParser.toLong(item.getVolume()); // 거래량 변환
+
+        stockPriceRepository.findByCompanyIdAndTradeDate(company.getId(), tradeDate)
+                .ifPresentOrElse( // 기존 레코드가 있다면 값 갱신
+                        existing -> existing.updatePrice(
+                                openPrice,
+                                highPrice,
+                                lowPrice,
+                                closePrice,
+                                closePrice, // 일봉 데이터에서는 currentPrice도 closePrice와 동일하게 저장
+                                volume,
+                                StockPriceSource.KIS
+                        ),
+
+                        () -> stockPriceRepository.save( // 기존 레코드가 없다면 새 StockPrice 저장
+                                StockPrice.builder()
+                                        .company(company)
+                                        .tradeDate(tradeDate)
+                                        .openPrice(openPrice)
+                                        .highPrice(highPrice)
+                                        .lowPrice(lowPrice)
+                                        .closePrice(closePrice)
+                                        .currentPrice(closePrice)
+                                        .volume(volume)
+                                        .source(StockPriceSource.KIS)
+                                        .build()
+                        )
+                );
+    }
 }

--- a/src/main/java/com/gong/modu/util/ExternalDateParser.java
+++ b/src/main/java/com/gong/modu/util/ExternalDateParser.java
@@ -1,4 +1,77 @@
 package com.gong.modu.util;
 
-public class ExternalDateParser {
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+// 외부 API에서 내려오는 날짜 문자열을 LocalDate로 변환하는 유틸 클래스
+public final class ExternalDateParser {
+
+    // yyyyMMdd 형식 변환용 formatter
+    private static final DateTimeFormatter BASIC_DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    // 유틸 클래스는 객체를 만들 필요 없으므로 private 생성자로 인스턴스 생성을 막음
+    private ExternalDateParser() {}
+
+    // yyyyMMdd 형식 문자열을 LocalDate로 변환하는 메서드
+    public static LocalDate parseBasicDate(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        return LocalDate.parse(value.trim(), BASIC_DATE);
+    }
+
+    // 다양한 날짜 문자열에서 숫자만 추출해 yyyyMMdd로 변환하는 메서드
+    public static LocalDate parseFlexibleDate(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        String digits = value.replaceAll("[^0-9]", "");
+
+        if (digits.length() < 8) { // 날짜는 최소 8자리
+            return null;
+        }
+
+        return LocalDate.parse(digits.substring(0, 8), BASIC_DATE);
+    }
+
+    // 날짜 범위 문자열에서 첫 번째 날짜를 추출하는 메서드
+    public static LocalDate parseFirstDateFromRange(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        // 날짜처럼 보이는 패턴을 찾기 위한 정규식
+        Matcher matcher = Pattern
+                .compile("\\d{4}[^0-9]?\\d{1,2}[^0-9]?\\d{1,2}").matcher(value);
+
+        // 첫 번째 날짜를 찾으면 시작일로 보고 반환
+        if (matcher.find()) {
+            return parseFlexibleDate(matcher.group());
+        }
+
+        return null;
+    }
+
+    // 날짜 범위 문자열에서 마지막 날짜를 추출하는 메서드
+    public static LocalDate parseLastDateFromRange(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        Matcher matcher = Pattern
+                .compile("\\d{4}[^0-9]?\\d{1,2}[^0-9]?\\d{1,2}").matcher(value);
+
+        LocalDate lastDate = null;
+
+        while (matcher.find()) { // 정규식에 맞는 날짜를 찾을 때마다 반복
+            // 반복문이 끝나면 lastDate에는 가장 마지막 날짜가 남게 됨
+            lastDate = parseFlexibleDate(matcher.group());
+        }
+
+        return lastDate;
+    }
 }

--- a/src/main/java/com/gong/modu/util/ExternalNumberParser.java
+++ b/src/main/java/com/gong/modu/util/ExternalNumberParser.java
@@ -1,4 +1,45 @@
 package com.gong.modu.util;
 
-public class ExternalNumberParser {
+import java.math.BigDecimal;
+
+// 외부 API에서 문자열로 내려오는 숫자값을 Java 숫자 타입으로 변환하는 클래스
+public final class ExternalNumberParser {
+
+    private ExternalNumberParser() {}
+
+    // 문자열을 Long 타입으로 변환하는 메서드
+    public static Long toLong(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        String normalized = value.replace(",", "").trim();
+        if (normalized.isBlank() || "-".equals(normalized)) {
+            return null;
+        }
+
+        try {
+            return Long.parseLong(normalized);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    // 문자열을 BigDecimal 타입으로 변환하는 메서드
+    public static BigDecimal toBigDecimal(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        String normalized = value.replace(",", "").trim();
+        if (normalized.isBlank() || "-".equals(normalized)) {
+            return null;
+        }
+
+        try {
+            return new BigDecimal(normalized);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #6 #7 #27 

## 📝 작업 개요

공모주 정보 제공 서비스의 핵심 도메인 모델을 설계하고, DART/KIS 외부 API 기반 데이터 수집 파이프라인의 초기 구조를 구현했다.

공모주 상세 조회에 필요한 기업 정보, 공모 이벤트, 공모 조건, 공모 지표, 증권사, 공시 요약, 재무 하이라이트, 주가 데이터, 사용자 관심 공모주 및 청약 이력 도메인을 구성했다.

또한 DART와 KIS API 응답을 받아 DB에 저장/갱신할 수 있도록 Client, DTO, Parser, Sync Service, Scheduler 구조를 추가했다.

## 📑 주요 작업 내용

### 1. 공통 도메인 기반 구성

- 여러 엔티티에서 공통으로 사용하는 `BaseTimeEntity` 추가

- `created_at`, `updated_at` 공통 관리 구조 적용

- JPA Auditing 활성화를 위해 `@EnableJpaAuditing` 설정

### 2. 공모주 핵심 도메인 엔티티 구현

- `Company`

  - DART/KIS 기반 기업 기본정보 저장

  - 기업명, 영문명, 종목코드, 종목명, 법인구분, 시장구분, 업종코드, 설립일 관리

- `IpoEvent`

  - 공모주 일정과 이벤트의 중심 엔티티

  - 청약일, 수요예측일, 납입일, 환불일, 배정일, 상장일, 보호예수 해제일, 진행 상태 관리

- `IpoOffering`

  - 공모 조건 정보 저장

  - 희망공모가, 확정공모가, 공모주식수, 상장주식수, 균등배정, 일반배정 등 관리

- `IpoMetric`

  - 공모주 분석 지표 저장

  - 기관경쟁률, 의무보유확약, 일반청약경쟁률, 비례경쟁률, 유통가능물량 비율, 신호등 위험도 관리

### 3. 증권사 / 공시 / 데이터 출처 도메인 구현

- `Broker`

  - 증권사 마스터 정보 저장

- `IpoEventBroker`

  - 공모 이벤트와 증권사의 N:M 관계를 연결 엔티티로 구현

  - 공모 이벤트별 청약 가능 증권사, 인수 역할, 인수 수량/금액 관리

- `IpoDisclosureReport`

  - DART 공시 접수번호 기반 공시 원문 및 요약 결과 저장

  - 기업 요약, 재무제표 요약, 투자자 보호 장치, 투자 포인트, 리스크 요약 구조 반영

- `IpoDataFieldSource`

  - 공모주 데이터 필드별 출처 추적 구조 추가

  - API 직접값, 원문 파싱값, 수동 입력값, 계산값 구분 가능하도록 설계

### 4. 재무 / 주가 도메인 구현

- `CompanyFinancialHighlight`

  - DART 재무제표 API에서 가져온 핵심 재무 정보 저장

  - 매출액, 영업이익, 순이익, 자산총계, 부채총계, 자본총계 관리

- `StockPrice`

  - KIS API 기반 주가 및 거래량 이력 저장

  - 시가, 고가, 저가, 종가, 현재가, 거래량, 데이터 출처 관리

### 5. 사용자 공모주 활동 도메인 구현

- `UserSubscriptionHistory`

  - 사용자의 공모주 청약 이력 관리

  - 서비스에 등록된 공모 이벤트 연결 또는 직접 입력 방식 모두 지원

  - 청약 수량, 배정 수량, 청약금액, 매도가, 수수료, 세금, 매도일, 메모 관리

- `UserInterestIpo`

  - 사용자 관심 공모주 저장 기능 구현

  - 동일 사용자가 동일 공모주를 중복 관심 등록하지 않도록 unique 제약 적용

### 6. Enum 추가

- 시장 구분: `MarketType`

- DART 법인 구분: `CorpClass`

- 공모 이벤트 유형: `IpoEventType`

- 공모 이벤트 상태: `IpoEventStatus`

- 공모주 위험 신호등: `SignalLevel`

- 증권사 역할: `BrokerRole`

- 데이터 출처 유형: `DataSourceType`

- 데이터 제공자: `DataSourceProvider`

- 보고서 코드: `ReportCode`

- 재무제표 구분: `FinancialStatementType`

- 주가 출처: `StockPriceSource`

- 사용자 청약 이력 상태: `SubscriptionRecordStatus`

### 7. Repository Layer 구현

공모주 도메인 조회 및 저장을 위해 다음 Repository를 추가했습니다.

- `CompanyRepository`

- `IpoEventRepository`

- `IpoOfferingRepository`

- `IpoMetricRepository`

- `BrokerRepository`

- `IpoEventBrokerRepository`

- `IpoDisclosureReportRepository`

- `IpoDataFieldSourceRepository`

- `CompanyFinancialHighlightRepository`

- `StockPriceRepository`

- `UserSubscriptionHistoryRepository`

- `UserInterestIpoRepository`

주요 조회 기능:

- corpCode / stockCode 기반 기업 조회

- 공모 이벤트 상태, 시장, 청약일, 상장일 기준 조회

- 공모 이벤트별 공모 조건/지표 조회

- 공모 이벤트별 증권사 목록 조회

- 공시 접수번호 기반 공시 조회

- 기업별 최신 재무정보 조회

- 기업별 기간별 주가 조회

- 사용자별 관심 공모주 및 청약 이력 조회

### 8. 외부 API 설정 및 Client 구현

KRX는 비용 및 승인 부담을 고려하여 제외하고, DART와 KIS 중심으로 외부 데이터 수집 구조를 구성했다.

- `WebClientConfig`

  - DART 전용 WebClient Bean 추가

  - KIS 전용 WebClient Bean 추가

- `DartApiClient`

  - DART 공시검색 API 호출

  - DART 기업개황 API 호출

  - DART 단일회사 전체 재무제표 API 호출

  - DART 지분증권 증권신고서 주요정보 API 호출

  - DART 응답 status 검증 및 공통 예외 처리

- `KisTokenClient`

  - KIS 접근 토큰 발급

  - Redis 기반 access token 캐싱

  - 토큰 TTL 23시간 설정

- `KisStockApiClient`

  - KIS 현재가 API 호출

  - KIS 기간별 시세 API 호출

  - KIS 응답 result code 검증 및 공통 예외 처리

### 9. 외부 API 응답 DTO 구현

- DART

  - `DartDisclosureSearchResponse`

  - `DartCompanyResponse`

  - `DartFinancialStatementResponse`

  - `DartEquitySecuritiesReportResponse`

- KIS

  - `KisTokenResponse`

  - `KisCurrentPriceResponse`

  - `KisDailyPriceResponse`

### 10. 외부 응답 파싱 유틸 구현

- `ExternalDateParser`

  - `yyyyMMdd` 문자열 변환

  - 다양한 날짜 문자열에서 숫자 추출 후 `LocalDate` 변환

  - 날짜 범위 문자열에서 시작일/종료일 추출

- `ExternalNumberParser`

  - 콤마가 포함된 숫자 문자열을 `Long`으로 변환

  - 가격/금액 문자열을 `BigDecimal`로 변환

  - 빈 문자열, `-`, 변환 불가능한 값은 `null` 처리

### 11. Data Pipeline / Sync Service 구현

- `DartCompanySyncService`

  - DART 기업개황 API 응답을 `Company`로 저장/갱신

- `DartFinancialSyncService`

  - DART 재무제표 응답에서 핵심 계정과목을 추출

  - `CompanyFinancialHighlight` 저장/갱신

- `DartIpoSyncService`

  - DART 공시검색 API와 지분증권 주요정보 API 기반 공모 이벤트 저장/갱신

  - `IpoEvent`, `IpoOffering`, `Broker`, `IpoEventBroker`, `IpoDisclosureReport` 저장/갱신

- `KisStockPriceSyncService`

  - KIS 현재가 및 기간별 시세 응답을 `StockPrice`로 저장/갱신

### 12. Scheduler 구현

- `SchedulingConfig`

  - `@Scheduled` 기능 활성화

- `ExternalDataScheduler`

  - 평일 오후 6시 KIS 주가 동기화 실행

  - 종목코드가 존재하는 기업만 대상으로 현재가 및 최근 7일 일봉 데이터 갱신

  - 특정 기업 동기화 실패 시 전체 배치가 중단되지 않도록 기업별 예외 처리

### 13. ErrorCode 확장

외부 API 및 공모주 데이터 처리에 필요한 에러 코드를 추가했다.

- `DART_API_ERROR`

- `KIS_API_ERROR`

- `KIS_TOKEN_ERROR`

- `EXTERNAL_API_EMPTY_RESPONSE`

- `COMPANY_NOT_FOUND`

- `STOCK_CODE_NOT_FOUND`

- `IPO_EVENT_NOT_FOUND`

---

## 🏗️ 설계 의도

### 1. DART/KIS 중심 데이터 수집 구조

초기 설계에서는 KRX API도 검토했지만, 비용 및 승인 절차 부담을 고려하여 현재 구현 범위에서는 제외했습니다.

대신 기업/공시/재무 데이터는 DART, 상장 후 주가 및 거래량 데이터는 KIS API로 대체했습니다.

### 2. 원천 데이터와 파생/보정 데이터 구분

기관경쟁률, 의무보유확약, 일반청약경쟁률, 비례경쟁률, 보호예수, 유통가능물량 등은 API에서 항상 직접 제공되지 않을 수 있으므로 nullable 구조로 설계했습니다.  

추후 원문 파싱 또는 관리자 보정이 필요한 값은 `IpoDataFieldSource`를 통해 출처를 추적할 수 있도록 했습니다.

### 3. 공모주 상세 화면 대응

와이어프레임의 청약/예측/기업 탭에서 필요한 데이터를 조회할 수 있도록 테이블을 분리했습니다.

- 청약 탭: `IpoEvent`, `IpoOffering`, `IpoMetric`

- 예측 탭: `IpoOffering`, `IpoMetric`

- 기업 탭: `Company`, `CompanyFinancialHighlight`, `IpoOffering`, `IpoEventBroker`

### 4. 과도한 테이블 분리 방지

설문 문항처럼 고정된 구조는 별도 answer 테이블로 분리하지 않고 기존 구현을 유지했습니다.  

반면 공모주-증권사 관계처럼 연결 자체에 역할, 인수 수량, 인수 금액 등 속성이 필요한 경우에는 연결 엔티티로 분리했습니다.

### 5. 재수집/갱신 가능한 구조

외부 API 데이터는 한 번만 저장되는 것이 아니라 재수집될 수 있으므로, 대부분의 Sync Service는 insert-only가 아니라 upsert 방식으로 구현했습니다.

## ⚠ 주의사항 및 후속 작업
- DART 주요정보 API만으로 수요예측일, 환불일, 상장일, 보호예수 해제일, 기관경쟁률, 의무보유확약 등을 모두 채우기는 어렵습니다.
- 현재는 DART에서 명확히 제공되는 청약기일, 납입일, 배정공고일, 청약공고일, 배정기준일, 인수기관명을 우선 저장합니다.
- 부족한 값은 추후 공시 원문 파싱 또는 보정 로직으로 보완해야하므로 후속 작업으로 진행될 예정입니다.

## 🧪 검증

### API Client 단위 테스트
<img width="1498" height="830" alt="image" src="https://github.com/user-attachments/assets/d40ca342-b18c-4d2f-9aad-69be32c176ea" />
종목코드 하나를 넣고 db에 insert가 잘 되는지, 기업명은 잘 받아오는지 테스트해봤다.
결과로, insert 쿼리가 정상적으로 실행되어 companyId = 1로 들어간 것을 확인할 수 있었고, 입력했던 종목코드에 맞는 기업명 삼성전자(주)도 잘 가져오는 것을 확인했다.