### PR TITLE
[Feat] DART 공시 원문 파싱 로직: 공모주 상세정보 완성도를 높이기 위한 2차 데이터 수집 파이프라인

### DIFF
--- a/src/main/java/com/gong/modu/client/DartApiClient.java
+++ b/src/main/java/com/gong/modu/client/DartApiClient.java
@@ -164,4 +164,29 @@ public class DartApiClient {
             throw new CustomException(ErrorCode.DART_API_ERROR);
         }
     }
+
+    // DART 공시서류원본파일 API를 호출하여 공시 원문 ZIP 파일을 byte[]로 다운로드하는 메서드
+    public byte[] downloadDisclosureDocumentZip(String rceptNo) {
+        try {
+            byte[] response = dartWebClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/api/document.xml") // 공시서류원본파일 API 경로
+                            .queryParam("crtfc_key", apiKey) // DART 인증키
+                            .queryParam("rcept_no", rceptNo) // 다운로드할 공시의 접수번호
+                            .build())
+                    .retrieve()
+                    .bodyToMono(byte[].class) // HTTP 응답 body를 byte[]로 받음
+                    .block();
+
+            if (response == null || response.length == 0) {
+                throw new CustomException(ErrorCode.EXTERNAL_API_EMPTY_RESPONSE);
+            }
+
+            return response; // zip 바이너리 반환
+        } catch (WebClientResponseException e) {
+            throw new CustomException(ErrorCode.DART_API_ERROR);
+        } catch (WebClientRequestException e) {
+            throw new CustomException(ErrorCode.DART_API_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/gong/modu/config/SecurityConfig.java
+++ b/src/main/java/com/gong/modu/config/SecurityConfig.java
@@ -54,7 +54,9 @@ public class SecurityConfig {
                                 // YouTube 자막 추출 검증용 API
                                 "/api/youtube/random-transcript",
                                 // 유튜브 자막 추출 & 요약용 관리자 API
-                                "/api/youtube/admin/**"
+                                "/api/youtube/admin/**",
+                                // 공시 원문 파서 테스트용 API
+                                "/api/test/disclosure-parser/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/gong/modu/controller/test/DisclosureParserTestController.java
+++ b/src/main/java/com/gong/modu/controller/test/DisclosureParserTestController.java
@@ -1,0 +1,107 @@
+package com.gong.modu.controller.test;
+
+import com.gong.modu.client.DartApiClient;
+import com.gong.modu.domain.dto.pipeline.IpoDisclosureParsingResult;
+import com.gong.modu.domain.dto.test.DisclosureParserTestResponse;
+import com.gong.modu.domain.dto.test.DisclosureTextParseTestRequest;
+import com.gong.modu.service.pipeline.DartDisclosureParsingService;
+import com.gong.modu.service.pipeline.DisclosureTextExtractor;
+import com.gong.modu.service.pipeline.IpoDisclosureDocumentClassifier;
+import com.gong.modu.service.pipeline.IpoDisclosureTextParser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Profile({"local", "local-test"})
+@RestController
+@RequestMapping("/api/test/disclosure-parser")
+@RequiredArgsConstructor
+public class DisclosureParserTestController {
+
+    private final DartApiClient dartApiClient;
+    private final DisclosureTextExtractor disclosureTextExtractor;
+    private final IpoDisclosureTextParser ipoDisclosureTextParser;
+    private final IpoDisclosureDocumentClassifier ipoDisclosureDocumentClassifier;
+    private final DartDisclosureParsingService dartDisclosureParsingService;
+
+    // 원문 텍스트만 직접 넣어서 parser 결과를 확인하는 테스트 API
+    // 사용 목적
+    // - 정규식이 수요예측일, 공모가, 기관경쟁률 등을 제대로 잡는지 빠르게 확인
+    // - 실제 ZIP 다운로드 없이 parser만 단독 검증
+    @PostMapping("/parse-text")
+    public ResponseEntity<DisclosureParserTestResponse> parseText(
+            @RequestBody @Valid DisclosureTextParseTestRequest request
+    ) {
+        String originalText = request.getText();
+
+        IpoDisclosureParsingResult parsingResult = ipoDisclosureTextParser.parse(originalText);
+
+        return ResponseEntity.ok(
+                DisclosureParserTestResponse.builder()
+                        .rceptNo(null)
+                        .originalTextLength(originalText.length())
+                        .originalTextPreview(makePreview(originalText))
+                        .ipoDocumentCandidate(ipoDisclosureDocumentClassifier.isIpoCandidate(originalText))
+                        .detectedDocumentType(ipoDisclosureDocumentClassifier.detectDocumentType(originalText))
+                        .matchedKeywords(ipoDisclosureDocumentClassifier.findMatchedIpoKeywords(originalText))
+                        .parsingResult(parsingResult)
+                        .build()
+        );
+    }
+
+    // 실제 DART rceptNo로 ZIP을 다운로드하고, 파일 내부 텍스트 추출과 정규식 파싱 결과를 함께 확인하는 테스트 API
+    // 사용 목적
+    // - DART 공시서류원본파일 API가 정상 호출되는지 확인
+    // - ZIP 내부 텍스트 추출이 정상적으로 되는지 확인
+    // - 실제 공시 문서에서 정규식 파싱 결과가 나오는지 확인
+    @GetMapping("/dry-run/{rceptNo}")
+    public ResponseEntity<DisclosureParserTestResponse> dryRunByRceptNo(
+            @PathVariable String rceptNo
+    ) {
+        byte[] zipBytes = dartApiClient.downloadDisclosureDocumentZip(rceptNo);
+
+        String originalText = disclosureTextExtractor.extractTextFromZip(zipBytes);
+
+        IpoDisclosureParsingResult parsingResult = ipoDisclosureTextParser.parse(originalText);
+
+        return ResponseEntity.ok(
+                DisclosureParserTestResponse.builder()
+                        .rceptNo(rceptNo)
+                        .originalTextLength(originalText.length())
+                        .originalTextPreview(makePreview(originalText))
+                        .ipoDocumentCandidate(ipoDisclosureDocumentClassifier.isIpoCandidate(originalText))
+                        .detectedDocumentType(ipoDisclosureDocumentClassifier.detectDocumentType(originalText))
+                        .matchedKeywords(ipoDisclosureDocumentClassifier.findMatchedIpoKeywords(originalText))
+                        .parsingResult(parsingResult)
+                        .build()
+        );
+    }
+
+    // 실제 DART rceptNo로 ZIP 다운로드, 텍스트 추출, 파싱, DB 반영까지 수행하는 테스트 API
+    // 사용 목적
+    // - DartDisclosureParsingService 전체 흐름 검증
+    // - 스케줄러가 내부적으로 수행할 작업을 단건으로 먼저 테스트
+    @PostMapping("/apply")
+    public ResponseEntity<Void> parseAndApply(
+            @RequestParam Long ipoEventId,
+            @RequestParam String rceptNo
+    ) {
+        dartDisclosureParsingService.parseDisclosureReport(ipoEventId, rceptNo);
+
+        return ResponseEntity.ok().build();
+    }
+
+    // 원문의 앞부분 일부만 잘라서 미리보기로 반환하는 메서드
+    private String makePreview(String text) {
+        if (text == null || text.isBlank()) {
+            return "";
+        }
+
+        int previewLength = Math.min(text.length(), 1000);
+
+        return text.substring(0, previewLength);
+    }
+
+}

--- a/src/main/java/com/gong/modu/domain/dto/IpoDisclosureParsingResult.java
+++ b/src/main/java/com/gong/modu/domain/dto/IpoDisclosureParsingResult.java
@@ -1,0 +1,52 @@
+package com.gong.modu.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+// 공시 원문 텍스트에서 추출한 IPO 핵심 값들을 임시로 담는 DTO
+public class IpoDisclosureParsingResult {
+
+    // 수요예측 시작일
+    private LocalDate demandForecastStart;
+
+    // 수요예측 종료일
+    private LocalDate demandForecastEnd;
+
+    // 환불일
+    private LocalDate refundDate;
+
+    // 상장일
+    private LocalDate listingDate;
+
+    // 락업해제일
+    private LocalDate lockupExpiryDate;
+
+    // 희망 공모가 하단
+    private BigDecimal offerPriceMin;
+
+    // 희망 공모가 상단
+    private BigDecimal offerPriceMax;
+
+    // 확정 공모가
+    private BigDecimal offerPrice;
+
+    // 공모주식수
+    private Long shareCount;
+
+    // 상장주식수
+    private Long totalListedShares;
+
+    // 기관경쟁률
+    private BigDecimal institutionalCompetitionRate;
+
+    // 의무보유확약 비율
+    private BigDecimal lockupRatio;
+
+    // 보호예수 비율
+    private BigDecimal protectiveCustodyRatio;
+}

--- a/src/main/java/com/gong/modu/domain/dto/pipeline/IpoDisclosureParsingResult.java
+++ b/src/main/java/com/gong/modu/domain/dto/pipeline/IpoDisclosureParsingResult.java
@@ -1,4 +1,4 @@
-package com.gong.modu.domain.dto;
+package com.gong.modu.domain.dto.pipeline;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/gong/modu/domain/dto/test/DisclosureParserTestResponse.java
+++ b/src/main/java/com/gong/modu/domain/dto/test/DisclosureParserTestResponse.java
@@ -1,0 +1,33 @@
+package com.gong.modu.domain.dto.test;
+
+import com.gong.modu.domain.dto.pipeline.IpoDisclosureParsingResult;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class DisclosureParserTestResponse {
+
+    // 파싱 대상 공시 접수번호
+    private String rceptNo;
+
+    // 원문 텍스트 길이
+    private int originalTextLength;
+
+    // 원문 일부 미리보기
+    private String originalTextPreview;
+
+    // 이 문서가 IPO/공모주 parser 대상 문서로 보이는지 여부
+    private boolean ipoDocumentCandidate;
+
+    // 원문에서 감지한 문서 유형 또는 대표 제목
+    private String detectedDocumentType;
+
+    // 원문에서 발견한 IPO 관련 키워드 목록
+    private List<String> matchedKeywords;
+
+    // 실제 정규식 파서가 추출한 결과
+    private IpoDisclosureParsingResult parsingResult;
+}

--- a/src/main/java/com/gong/modu/domain/dto/test/DisclosureTextParseTestRequest.java
+++ b/src/main/java/com/gong/modu/domain/dto/test/DisclosureTextParseTestRequest.java
@@ -1,0 +1,14 @@
+package com.gong.modu.domain.dto.test;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DisclosureTextParseTestRequest {
+
+    // 테스트할 공시 원문 텍스트
+    @NotBlank
+    private String text;
+}

--- a/src/main/java/com/gong/modu/domain/entity/ipo/IpoEvent.java
+++ b/src/main/java/com/gong/modu/domain/entity/ipo/IpoEvent.java
@@ -152,4 +152,39 @@ public class IpoEvent extends BaseTimeEntity {
         this.marketType = marketType;
         this.mainReportRceptNo = mainReportRceptNo;
     }
+
+    // 공시 원문 파싱으로 얻은 일정 값만 선택적으로 반영하는 메서드
+    public void updateParsedSchedule(
+            LocalDate demandForecastStart,
+            LocalDate demandForecastEnd,
+            LocalDate refundDate,
+            LocalDate listingDate,
+            LocalDate lockupExpiryDate
+    ) {
+
+        // 파싱된 수요예측 시작일이 있을 때만 기존 값을 갱신
+        if (demandForecastStart != null) {
+            this.demandForecastStart = demandForecastStart;
+        }
+
+        // 파싱된 수요예측 종료일이 있을 때만 기존 값을 갱신
+        if (demandForecastEnd != null) {
+            this.demandForecastEnd = demandForecastEnd;
+        }
+
+        // 파싱된 환불일이 있을 때만 기존 값을 갱신
+        if (refundDate != null) {
+            this.refundDate = refundDate;
+        }
+
+        // 파싱된 상장일이 있을 때만 기존 값을 갱신
+        if (listingDate != null) {
+            this.listingDate = listingDate;
+        }
+
+        // 파싱된 보호예수 해제일이 있을 때만 기존 값을 갱신
+        if (lockupExpiryDate != null) {
+            this.lockupExpiryDate = lockupExpiryDate;
+        }
+    }
 }

--- a/src/main/java/com/gong/modu/domain/entity/ipo/IpoMetric.java
+++ b/src/main/java/com/gong/modu/domain/entity/ipo/IpoMetric.java
@@ -92,4 +92,27 @@ public class IpoMetric extends BaseTimeEntity {
         this.signalLevel = signalLevel;
         this.computedAt = computedAt;
     }
+
+    // 공시 원문 파싱으로 얻은 지표 값을 선택적으로 반영하는 메서드
+    public void updateParsedMetrics(
+            BigDecimal institutionalCompetitionRate,
+            BigDecimal lockupRatio,
+            BigDecimal protectiveCustodyRatio
+    ) {
+
+        // 기관경쟁률이 파싱된 경우에만 갱신
+        if (institutionalCompetitionRate != null) {
+            this.institutionalCompetitionRate = institutionalCompetitionRate;
+        }
+
+        // 의무보유확약 비율이 파싱된 경우에만 갱신
+        if (lockupRatio != null) {
+            this.lockupRatio = lockupRatio;
+        }
+
+        // 보호예수 비율이 파싱된 경우에만 갱신
+        if (protectiveCustodyRatio != null) {
+            this.protectiveCustodyRatio = protectiveCustodyRatio;
+        }
+    }
 }

--- a/src/main/java/com/gong/modu/domain/entity/ipo/IpoOffering.java
+++ b/src/main/java/com/gong/modu/domain/entity/ipo/IpoOffering.java
@@ -19,7 +19,7 @@ import java.time.LocalDate;
 @Table(name = "ipo_offerings")
 public class IpoOffering extends BaseTimeEntity {
 
-    @Id // 기본키입니다.
+    @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -109,12 +109,53 @@ public class IpoOffering extends BaseTimeEntity {
         this.generalAllocationShares = generalAllocationShares;
     }
 
+    // 공시 원문 파싱으로 얻은 공모 조건 값을 선택적으로 반영하는 메서드
+    public void updateParsedOfferingInfo(
+            Long shareCount,
+            Long totalListedShares,
+            BigDecimal offerPriceMin,
+            BigDecimal offerPriceMax,
+            BigDecimal offerPrice
+    ) {
+        // 공모주식수가 파싱된 경우에만 갱신
+        if (shareCount != null) {
+            this.shareCount = shareCount;
+        }
+
+        // 상장주식수가 파싱된 경우에만 갱신
+        if (totalListedShares != null) {
+            this.totalListedShares = totalListedShares;
+        }
+
+        // 희망 공모가 하단이 파싱된 경우에만 갱신
+        if (offerPriceMin != null) {
+            this.offerPriceMin = offerPriceMin;
+        }
+
+        // 희망 공모가 상단이 파싱된 경우에만 갱신
+        if (offerPriceMax != null) {
+            this.offerPriceMax = offerPriceMax;
+        }
+
+        // 확정 공모가가 파싱된 경우에만 갱신
+        if (offerPrice != null) {
+            this.offerPrice = offerPrice;
+        }
+    }
+
     // 청약 공고일, 배정 기준일 갱신 메서드
     public void updateOfferingDates(
             LocalDate subscriptionNoticeDate,
             LocalDate allocationBaseDate
     ) {
-        this.subscriptionNoticeDate = subscriptionNoticeDate;
-        this.allocationBaseDate = allocationBaseDate;
+        // 청약공고일이 null이 아닐 때만 갱신
+        if (subscriptionNoticeDate != null) {
+            this.subscriptionNoticeDate = subscriptionNoticeDate;
+        }
+
+        // 배정기준일이 null이 아닐 때만 갱신
+        if (allocationBaseDate != null) {
+            this.allocationBaseDate = allocationBaseDate;
+        }
     }
 }

--- a/src/main/java/com/gong/modu/exception/ErrorCode.java
+++ b/src/main/java/com/gong/modu/exception/ErrorCode.java
@@ -59,7 +59,10 @@ public enum ErrorCode {
     IPO_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "공모주 정보를 찾을 수 없습니다."),
     DISCLOSURE_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공모주의 공시 리포트를 찾을 수 없습니다."),
     FINANCIAL_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "기업 재무 정보를 찾을 수 없습니다."),
-    STOCK_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "종목코드가 없어 주가를 조회할 수 없습니다.");
+    STOCK_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "종목코드가 없어 주가를 조회할 수 없습니다."),
+
+    // DART 원문 공시 ZIP을 받았지만 텍스트 추출 또는 파싱에 실패한 경우
+    DISCLOSURE_PARSING_FAILED(HttpStatus.BAD_GATEWAY, "공시 원문 파싱 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/gong/modu/repository/ipo/IpoDisclosureReportRepository.java
+++ b/src/main/java/com/gong/modu/repository/ipo/IpoDisclosureReportRepository.java
@@ -1,6 +1,7 @@
 package com.gong.modu.repository.ipo;
 
 import com.gong.modu.domain.entity.ipo.IpoDisclosureReport;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -21,6 +22,7 @@ public interface IpoDisclosureReportRepository extends JpaRepository<IpoDisclosu
     // 공시명에 특정 키워드가 포함된 공시 목록 조회
     List<IpoDisclosureReport> findByReportNameContaining(String keyword);
 
-    // AI 요약이 아직 생성되지 않은 공시 목록 조회 (배치 대상)
-    List<IpoDisclosureReport> findByCompanySummaryIsNull();
+    // original_text가 아직 없는 공시를 일부만 조회
+    List<IpoDisclosureReport> findByOriginalTextIsNull(Pageable pageable);
+
 }

--- a/src/main/java/com/gong/modu/scheduler/ExternalDataScheduler.java
+++ b/src/main/java/com/gong/modu/scheduler/ExternalDataScheduler.java
@@ -1,10 +1,8 @@
 package com.gong.modu.scheduler;
 
 import com.gong.modu.domain.entity.ipo.Company;
-import com.gong.modu.domain.entity.ipo.IpoDisclosureReport;
 import com.gong.modu.repository.ipo.CompanyRepository;
-import com.gong.modu.repository.ipo.IpoDisclosureReportRepository;
-import com.gong.modu.service.ipo.IpoDisclosureReportSummarizeService;
+import com.gong.modu.service.pipeline.DartDisclosureParsingService;
 import com.gong.modu.service.pipeline.KisStockPriceSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,9 +21,21 @@ public class ExternalDataScheduler {
     private static final DateTimeFormatter BASIC_DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private final CompanyRepository companyRepository;
-    private final KisStockPriceSyncService kisStockPriceSyncService;
-    private final IpoDisclosureReportRepository disclosureReportRepository;
-    private final IpoDisclosureReportSummarizeService summarizeService;
+    private final KisStockPriceSyncService kisStockPriceSyncService; // 실제 KIS 주가 동기화 로직을 실행할 서비스
+
+    private final DartDisclosureParsingService dartDisclosureParsingService; // DART 공시 원문 다운/파싱 로직을 실행하는 서비스
+
+    @Scheduled(cron = "0 0 2 * * *")
+    public void parseUnparsedDartDisclosureDocuments() {
+        log.info("[Scheduler] DART 공시 원문 ZIP 파싱 시작");
+        try {
+            dartDisclosureParsingService.parseUnparsedDisclosureReports(20);
+        } catch (Exception e) {
+            log.error("[Scheduler] DART 공시 원문 ZIP 파싱 실패", e);
+        }
+
+        log.info("[Scheduler] DART 공시 원문 ZIP 파싱 종료");
+    }
 
 
     // 상장 기업들의 KIS 주가 뎅ㅣ터를 동기화하는 스케줄러 메서드
@@ -56,38 +66,5 @@ public class ExternalDataScheduler {
         }
 
         log.info("[Scheduler] KIS 상장 기업 주가 동기화 종료"); // 배치 종료 로그
-    }
-
-    // AI 요약이 생성되지 않은 공모주 공시 레코드를 대상으로 Claude API를 호출해 요약을 생성하는 스케줄러
-    // 매일 오전 7시 실행, 레코드 간 1초 간격으로 Claude API 과부하 방지
-    @Scheduled(cron = "0 0 7 * * *")
-    public void summarizeIpoDisclosureReports() {
-        log.info("[Scheduler] 공모주 AI 요약 배치 시작");
-
-        List<IpoDisclosureReport> pending = disclosureReportRepository.findByCompanySummaryIsNull();
-        log.info("[Scheduler] 요약 대상: {}건", pending.size());
-
-        int success = 0;
-        int fail = 0;
-
-        for (IpoDisclosureReport report : pending) {
-            try {
-                summarizeService.summarize(report.getId());
-                success++;
-            } catch (Exception e) {
-                log.warn("[Scheduler] 요약 실패 reportId={}: {}", report.getId(), e.getMessage());
-                fail++;
-            }
-
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                log.warn("[Scheduler] 공모주 AI 요약 배치 인터럽트 발생, 배치 중단");
-                break;
-            }
-        }
-
-        log.info("[Scheduler] 공모주 AI 요약 배치 종료 - 성공: {}건, 실패: {}건", success, fail);
     }
 }

--- a/src/main/java/com/gong/modu/service/pipeline/DartDisclosureParsingService.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DartDisclosureParsingService.java
@@ -1,0 +1,178 @@
+package com.gong.modu.service.pipeline;
+
+import com.gong.modu.client.DartApiClient;
+import com.gong.modu.domain.dto.IpoDisclosureParsingResult;
+import com.gong.modu.domain.entity.ipo.IpoDisclosureReport;
+import com.gong.modu.domain.entity.ipo.IpoEvent;
+import com.gong.modu.domain.entity.ipo.IpoMetric;
+import com.gong.modu.domain.entity.ipo.IpoOffering;
+import com.gong.modu.exception.CustomException;
+import com.gong.modu.exception.ErrorCode;
+import com.gong.modu.repository.ipo.IpoDisclosureReportRepository;
+import com.gong.modu.repository.ipo.IpoEventRepository;
+import com.gong.modu.repository.ipo.IpoMetricRepository;
+import com.gong.modu.repository.ipo.IpoOfferingRepository;
+import com.gong.modu.util.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+// DART 공시 원문 ZIP을 다운로드하고 텍스트를 추출한 뒤 일부 IPO 핵심값을 파싱하여 DB에 반영하는 서비스 클래스
+public class DartDisclosureParsingService {
+
+    private final DartApiClient dartApiClient;
+    private final DisclosureTextExtractor disclosureTextExtractor;
+    private final IpoDisclosureTextParser ipoDisclosureTextParser;
+    private final IpoEventRepository ipoEventRepository;
+    private final IpoOfferingRepository ipoOfferingRepository;
+    private final IpoMetricRepository ipoMetricRepository;
+    private final IpoDisclosureReportRepository disclosureReportRepository;
+    private final RedisUtil redisUtil;
+
+    // 아직 original_text가 없는 공시들을 일정 개수만큼 찾아 원문 ZIP 다운로드/파싱을 수행하는 메서드
+    public void parseUnparsedDisclosureReports(int limit) {
+        // 공시 조회
+        List<IpoDisclosureReport> reports = disclosureReportRepository
+                .findByOriginalTextIsNull(PageRequest.of(0, limit));
+
+        if (reports.isEmpty()) {
+            log.info("DART Disclosure Parsing] 미파싱 공시 없음");
+            return;
+        }
+
+        for (IpoDisclosureReport report : reports) {
+            String rceptNo = report.getRceptNo();
+
+            if (redisUtil.isDisclosureParsingRecentlyFailed(rceptNo)) {
+                log.info("[DART Disclosure Parsing] 최근 실패 이력으로 건너뜀: rceptNo={}", rceptNo);
+                continue;
+            }
+
+            // 같은 공시를 중복 파싱하지 않기 위한 Redis lock 획득
+            boolean locked = redisUtil.tryLockDisclosureParsing(rceptNo, 30);
+
+            if (!locked) {
+                log.info("[DART Disclosure Parsing] 이미 파싱 중인 공시로 건너뜀: rceptNo={}", rceptNo);
+                continue;
+            }
+
+            try {
+                // 각 공시마다 단건 파싱 메서드 호출
+                parseDisclosureReport(report.getIpoEvent().getId(), rceptNo);
+            } catch (Exception e) {
+                // 실패한 공시는 6시간 동안 재시도를 막음
+                redisUtil.markDisclosureParsingFailed(rceptNo, 6);
+
+                log.warn("[DART Disclosure Parsing] 공시 원문 파싱 실패: rceptNo={}", rceptNo, e);
+            } finally {
+                // 성공/실패 여부와 관계없이 lock은 해제
+                redisUtil.unlockDisclosureParsing(rceptNo);
+            }
+        }
+
+    }
+
+    @Transactional
+    public void parseDisclosureReport(Long ipoEventId, String rceptNo) {
+        IpoEvent ipoEvent = ipoEventRepository.findById(ipoEventId)
+                .orElseThrow(() -> new CustomException(ErrorCode.IPO_EVENT_NOT_FOUND));
+
+
+        // DART 공시 원문 다운로드
+        byte[] zipBytes = dartApiClient.downloadDisclosureDocumentZip(rceptNo);
+
+        // 텍스트 추출
+        String originalText = disclosureTextExtractor.extractTextFromZip(zipBytes);
+
+        if (originalText == null || originalText.isBlank()) {
+            throw new CustomException(ErrorCode.DISCLOSURE_PARSING_FAILED);
+        }
+
+        // ipo_disclosure_reports에 원문 텍스트를 저장하거나 갱신
+        upsertDisclosureOriginalText(ipoEvent, rceptNo, originalText);
+
+        // 원문 텍스트에 핵심 IPO 값을 파싱
+        IpoDisclosureParsingResult parsingResult = ipoDisclosureTextParser.parse(originalText);
+
+        // 파싱 결과를 ipo_events, ipo_offerings, ipo_metrics에 반영
+        applyParsingResult(ipoEvent, parsingResult);
+
+    }
+
+    // 공시 원문 텍스트를 ipo_disclosure_reports에에 저장하거나 갱신하는 메서드
+    private IpoDisclosureReport upsertDisclosureOriginalText(
+            IpoEvent ipoEvent,
+            String rceptNo,
+            String originalText
+    ) {
+        return disclosureReportRepository.findByIpoEventIdAndRceptNo(ipoEvent.getId(), rceptNo)
+                .map(existing -> {
+                    // 기존 공시 레코드의 원문 텍스트를 최신 추출 결과로 갱신
+                    existing.updateOriginalText(originalText);
+
+                    return existing;
+                })
+                .orElseGet(() -> disclosureReportRepository.save(
+                        IpoDisclosureReport.builder()
+                                .ipoEvent(ipoEvent)
+                                .rceptNo(rceptNo)
+                                .reportName("DART 원문 공시") // 임시명
+                                .originalText(originalText)
+                                .build()
+                ));
+    }
+
+    // 파싱 결과를 각 엔티티에 반영하는 메서드
+    private void applyParsingResult(
+            IpoEvent ipoEvent,
+            IpoDisclosureParsingResult result
+    ) {
+        // 공시 원문에서 추출한 일정 정보를 ipo_events에 반영
+        ipoEvent.updateParsedSchedule(
+                result.getDemandForecastStart(),
+                result.getDemandForecastEnd(),
+                result.getRefundDate(),
+                result.getListingDate(),
+                result.getLockupExpiryDate()
+        );
+
+        // 공모조건
+        IpoOffering offering = ipoOfferingRepository.findByIpoEventId(ipoEvent.getId())
+                .orElseGet(() -> ipoOfferingRepository.save(
+                        IpoOffering.builder()
+                                .ipoEvent(ipoEvent)
+                                .build()
+                ));
+
+        // 파싱된 공모가, 공모주식수, 상장주식수를 공모 조건에 반영
+        offering.updateParsedOfferingInfo(
+                result.getShareCount(),
+                result.getTotalListedShares(),
+                result.getOfferPriceMin(),
+                result.getOfferPriceMax(),
+                result.getOfferPrice()
+        );
+
+        // 공모지표
+        IpoMetric metric = ipoMetricRepository.findByIpoEventId(ipoEvent.getId())
+                .orElseGet(() -> ipoMetricRepository.save(
+                        IpoMetric.builder()
+                                .ipoEvent(ipoEvent)
+                                .build()
+                ));
+
+        // 파싱된 기관경쟁률, 의무보유확약, 락업 비율을 지표에 반영
+        metric.updateParsedMetrics(
+                result.getInstitutionalCompetitionRate(),
+                result.getLockupRatio(),
+                result.getProtectiveCustodyRatio()
+        );
+    }
+}

--- a/src/main/java/com/gong/modu/service/pipeline/DartDisclosureParsingService.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DartDisclosureParsingService.java
@@ -1,7 +1,7 @@
 package com.gong.modu.service.pipeline;
 
 import com.gong.modu.client.DartApiClient;
-import com.gong.modu.domain.dto.IpoDisclosureParsingResult;
+import com.gong.modu.domain.dto.pipeline.IpoDisclosureParsingResult;
 import com.gong.modu.domain.entity.ipo.IpoDisclosureReport;
 import com.gong.modu.domain.entity.ipo.IpoEvent;
 import com.gong.modu.domain.entity.ipo.IpoMetric;
@@ -35,6 +35,7 @@ public class DartDisclosureParsingService {
     private final IpoMetricRepository ipoMetricRepository;
     private final IpoDisclosureReportRepository disclosureReportRepository;
     private final RedisUtil redisUtil;
+    private final IpoDisclosureDocumentClassifier ipoDisclosureDocumentClassifier;
 
     // 아직 original_text가 없는 공시들을 일정 개수만큼 찾아 원문 ZIP 다운로드/파싱을 수행하는 메서드
     public void parseUnparsedDisclosureReports(int limit) {
@@ -84,7 +85,6 @@ public class DartDisclosureParsingService {
         IpoEvent ipoEvent = ipoEventRepository.findById(ipoEventId)
                 .orElseThrow(() -> new CustomException(ErrorCode.IPO_EVENT_NOT_FOUND));
 
-
         // DART 공시 원문 다운로드
         byte[] zipBytes = dartApiClient.downloadDisclosureDocumentZip(rceptNo);
 
@@ -93,6 +93,20 @@ public class DartDisclosureParsingService {
 
         if (originalText == null || originalText.isBlank()) {
             throw new CustomException(ErrorCode.DISCLOSURE_PARSING_FAILED);
+        }
+
+        // 원문 텍스트 기준으로 IPO/공모주 관련 문서인지 한 번 더 판단
+        if (!ipoDisclosureDocumentClassifier.isIpoCandidate(originalText)) {
+            log.info(
+                    "[DART Disclosure Parsing] IPO 관련 공시가 아니므로 파싱 건너뜀: rceptNo={}, documentType={}",
+                    rceptNo,
+                    ipoDisclosureDocumentClassifier.detectDocumentType(originalText)
+            );
+
+            // 비 IPO 공시라도 원문 확인 이력은 남길 수 있으므로 original_text만 저장
+            upsertDisclosureOriginalText(ipoEvent, rceptNo, originalText);
+
+            return;
         }
 
         // ipo_disclosure_reports에 원문 텍스트를 저장하거나 갱신

--- a/src/main/java/com/gong/modu/service/pipeline/DartIpoSyncService.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DartIpoSyncService.java
@@ -238,4 +238,47 @@ public class DartIpoSyncService {
 
         return IpoEventStatus.UPCOMING; // 위 조건에 모두 해당하지 않으면 예정 상태
     }
+
+    // DART 공시검색 결과의 reportNm을 기준으로 공모주 관련 공시 후보인지 판단하는 메서드
+    private boolean isIpoDisclosureCandidate(String reportName) {
+        if (reportName == null || reportName.isBlank())
+            return false;
+
+        String name = reportName.trim();
+
+        // 공모주와 직접 관련될 가능성이 높은 보고서명
+        boolean hasIpoReportType =
+                name.contains("증권신고서")
+                    || name.contains("투자설명서")
+                    || name.contains("발행조건확정");
+
+        // 공모주와 관련된 키워드
+        // 보고서명이 길거나 정정 공시 형태일 때 보조 판단 기준으로 사용합
+        boolean hasIpoKeyword =
+                name.contains("지분증권")
+                        || name.contains("공모")
+                        || name.contains("모집")
+                        || name.contains("매출");
+
+        // 명백히 IPO 공시가 아닌 주요사항보고서 계열은 제외
+        boolean hasNonIpoKeyword =
+                name.contains("타법인 주식")
+                        || name.contains("출자증권")
+                        || name.contains("양도결정")
+                        || name.contains("취득결정")
+                        || name.contains("주요사항보고서")
+                        || name.contains("단일판매")
+                        || name.contains("공급계약")
+                        || name.contains("최대주주")
+                        || name.contains("사업보고서")
+                        || name.contains("반기보고서")
+                        || name.contains("분기보고서");
+
+        // 명백한 비 IPO 키워드가 있으면 제외
+        if (hasNonIpoKeyword)
+            return false;
+
+        // IPO 성격의 보고서 유형이 있거나, 공모 관련 키워드가 있으면 후보로 봄
+        return hasIpoReportType || hasIpoKeyword;
+    }
 }

--- a/src/main/java/com/gong/modu/service/pipeline/DisclosureTextExtractor.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DisclosureTextExtractor.java
@@ -1,0 +1,156 @@
+package com.gong.modu.service.pipeline;
+
+import com.gong.modu.exception.CustomException;
+import com.gong.modu.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+// DART 공시 원문 ZIP 파일에서 텍스트를 추출하는 클래스
+@Component
+public class DisclosureTextExtractor {
+
+    // 텍스트 추출 대상으로 볼 파일 확장자 목록
+    private static final Set<String> TEXT_EXTENSIONS = Set.of(
+            ".xml",
+            ".html",
+            ".htm",
+            ".txt"
+    );
+
+    // ZIP 파일 byte[]를 받아 내부 파일들의 텍스트를 하나로 합치는 메서드
+    public String extractTextFromZip(byte[] zipBytes) {
+        if (zipBytes == null || zipBytes.length == 0) {
+            return "";
+        }
+
+        StringBuilder result = new StringBuilder(); // 여러 파일에서 추출한 텍스트를 누적하기 위한 StringBuilder
+
+        try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+            ZipEntry entry;
+
+            while((entry = zipInputStream.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+
+                String fileName = entry.getName(); // ZIP 내부 파일명을 가져옴
+
+                // 텍스트 추출 대상 파일만 처리
+                if (!isTextFile(fileName)) {
+                    continue;
+                }
+
+                // 현재 ZIP entry의 바이트 내용을 읽음
+                byte[] fileBytes = readCurrentEntry(zipInputStream);
+
+                // 바이트 배열을 문자열로 변환
+                String rawText = decodeToString(fileBytes);
+
+                // HTML/XML 태그를 제거하고 공백을 정리
+                String plainText = stripMarkupAndNormalize(rawText);
+
+                // 어느 파일에서 추출했는지 구분하기 위해 파일명을 함께 남김
+                result.append("\n\n")
+                        .append("===== FILE: ")
+                        .append(fileName)
+                        .append(" =====\n")
+                        .append(plainText);
+            }
+        } catch (IOException e) { // ZIP 처리 중 IOException이 발생하면 공시 파싱 단계의 실패로 판단
+            throw new CustomException(ErrorCode.DISCLOSURE_PARSING_FAILED);
+        }
+
+        // 누적된 텍스트 반환
+        return result.toString().trim();
+    }
+
+    // 파일명이 텍스트 추출 대상 확장자인지 확인하는 메서드
+    private boolean isTextFile(String fileName) {
+        if (fileName == null)
+            return false;
+
+        String lowerName = fileName.toLowerCase();
+
+        return TEXT_EXTENSIONS.stream()
+                .anyMatch(lowerName::endsWith);
+    }
+
+    // 현재 Zip entry의 전체 바이트를 읽는 메서드
+    private byte[] readCurrentEntry(ZipInputStream zipInputStream) throws IOException {
+        // 읽은 데이터를 임시로 담을 저장소
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        // 한 번에 읽을 버퍼 크기
+        byte[] buffer = new byte[4096];
+
+        // 실제로 읽은 바이트 수를 담을 변수
+        int length;
+
+        while ((length = zipInputStream.read(buffer)) != -1) {
+            outputStream.write(buffer, 0, length);
+        }
+
+        return outputStream.toByteArray();
+    }
+
+    // byte[]를 문자열로 변환하는 메서드
+    private String decodeToString(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) {
+            return "";
+        }
+
+        // UTF-8로 디코딩
+        String utf8Text = new String(bytes, StandardCharsets.UTF_8);
+
+        if (!looksBroken(utf8Text)) {
+            return utf8Text;
+        }
+
+        return new String(bytes, Charset.forName("MS949"));
+    }
+
+    // 문자열이 깨졌는지 판단하는 메서드
+    private boolean looksBroken(String text) {
+        if (text == null)
+            return false;
+
+        // 유니코드 replacement character 개수를 셈
+        long brokenCount = text.chars()
+                .filter(ch -> ch == '\uFFFD')
+                .count();
+
+        return brokenCount >= 10;
+    }
+
+    // HTML/XML 태그를 제거하고 공백을 정리하는 메서드
+    private String stripMarkupAndNormalize(String rawText) {
+        if (rawText == null)
+            return "";
+
+        return rawText
+                // script 태그 내부는 화면 표시 텍스트가 아니므로 제거
+                .replaceAll("(?is)<script.*?</script>", " ")
+                // style 태그 내부도 화면 표시 텍스트가 아니므로 제거
+                .replaceAll("(?is)<style.*?</style>", " ")
+                // HTML/XML 태그를 제거
+                .replaceAll("(?s)<[^>]+>", " ")
+                // HTML 공백 엔티티를 일반 공백으로 바꿈
+                .replace("&nbsp;", " ")
+                // 자주 등장하는 HTML 엔티티를 처리
+                .replace("&amp;", "&")
+                // 여러 공백을 하나의 공백으로 줄임
+                .replaceAll("[ \\t\\x0B\\f\\r]+", " ")
+                // 여러 줄바꿈을 최대 두 줄 정도로 줄임
+                .replaceAll("\\n{3,}", "\n\n")
+                // 앞뒤 공백을 제거
+                .trim();
+    }
+}

--- a/src/main/java/com/gong/modu/service/pipeline/IpoDisclosureDocumentClassifier.java
+++ b/src/main/java/com/gong/modu/service/pipeline/IpoDisclosureDocumentClassifier.java
@@ -1,0 +1,120 @@
+package com.gong.modu.service.pipeline;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class IpoDisclosureDocumentClassifier {
+    private static final List<String> IPO_KEYWORDS = List.of(
+            "증권신고서",
+            "지분증권",
+            "투자설명서",
+            "공모",
+            "공모가",
+            "희망공모가",
+            "확정공모가",
+            "청약",
+            "수요예측",
+            "기관투자자",
+            "의무보유확약",
+            "보호예수",
+            "상장예정",
+            "모집",
+            "매출"
+    );
+
+    private static final List<String> NON_IPO_KEYWORDS = List.of(
+            "타법인 주식 및 출자증권 양도결정",
+            "타법인 주식 및 출자증권 취득결정",
+            "단일판매",
+            "공급계약",
+            "최대주주 변경",
+            "임원ㆍ주요주주",
+            "주식등의대량보유상황보고서",
+            "사업보고서",
+            "반기보고서",
+            "분기보고서"
+    );
+
+    public boolean isIpoCandidate(String text) {
+
+        if (text == null || text.isBlank()) {
+            return false;
+        }
+
+        String normalized = normalize(text);
+
+        boolean hasDisclosureTitle =
+                normalized.contains("증권신고서")
+                        || normalized.contains("투자설명서")
+                        || normalized.contains("정정신고서");
+
+        boolean hasEquityKeyword =
+                normalized.contains("지분증권")
+                        || normalized.contains("기명식 보통주")
+                        || normalized.contains("모집 또는 매출");
+
+        boolean hasIpoScheduleKeyword =
+                normalized.contains("청약")
+                        || normalized.contains("수요예측")
+                        || normalized.contains("공모가")
+                        || normalized.contains("상장예정");
+
+        return hasDisclosureTitle && hasEquityKeyword && hasIpoScheduleKeyword;
+    }
+
+    public List<String> findMatchedIpoKeywords(String text) {
+
+        List<String> result = new ArrayList<>();
+
+        if (text == null || text.isBlank()) {
+            return result;
+        }
+
+        String normalized = normalize(text);
+
+        for (String keyword : IPO_KEYWORDS) {
+            if (normalized.contains(keyword)) {
+                result.add(keyword);
+            }
+        }
+
+        return result;
+    }
+
+    public String detectDocumentType(String text) {
+
+        if (text == null || text.isBlank()) {
+            return "UNKNOWN";
+        }
+
+        String normalized = normalize(text);
+
+        if (normalized.contains("증권신고서")) {
+            return "증권신고서";
+        }
+
+        if (normalized.contains("투자설명서")) {
+            return "투자설명서";
+        }
+
+        if (normalized.contains("정정신고서")) {
+            return "정정신고서";
+        }
+
+        for (String keyword : NON_IPO_KEYWORDS) {
+            if (normalized.contains(keyword)) {
+                return keyword;
+            }
+        }
+
+        return "UNKNOWN";
+    }
+
+    private String normalize(String text) {
+        return text.replaceAll("\\s+", " ").trim();
+    }
+
+}

--- a/src/main/java/com/gong/modu/service/pipeline/IpoDisclosureTextParser.java
+++ b/src/main/java/com/gong/modu/service/pipeline/IpoDisclosureTextParser.java
@@ -31,7 +31,7 @@ public class IpoDisclosureTextParser {
         LocalDate refundDate = findDateNearKeyword(normalized, "상장일|상장예정일|매매개시일");
 
         // 상장일 추출
-        LocalDate listingDate = findDateNearKeyword(normalized, "상장일|상장예정일|매매개시일");
+        LocalDate listingDate = findDateNearKeyword(normalized, "환불일|환불기일|청약증거금.*환불|납입 및 환불");
 
         // 보호예수 해제일 또는 의무보유 해제일 추출
         LocalDate lockupExpiryDate = findDateNearKeyword(

--- a/src/main/java/com/gong/modu/service/pipeline/IpoDisclosureTextParser.java
+++ b/src/main/java/com/gong/modu/service/pipeline/IpoDisclosureTextParser.java
@@ -1,0 +1,275 @@
+package com.gong.modu.service.pipeline;
+
+import com.gong.modu.domain.dto.IpoDisclosureParsingResult;
+import com.gong.modu.util.ExternalDateParser;
+import com.gong.modu.util.ExternalNumberParser;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+// 공시 원문 텍스트에서 IPO 핵심값을 정규식 기반으로 추출하는 클래스
+// 텍스트에서 자주 등장하는 패턴을 우선 추출하는 1차 파서
+public class IpoDisclosureTextParser {
+
+    // 원문 텍스트를 받아 파싱 결과 DTO로 변환하는 메서드
+    public IpoDisclosureParsingResult parse(String text) {
+        if (text == null || text.isBlank()) {
+            return IpoDisclosureParsingResult.builder().build();
+        }
+
+        String normalized = normalize(text);
+
+        // 수요예측일 범위 추출
+        DateRange demandForecastRange = findDateRangeNearKeyword(normalized, "수요예측");
+
+        // 환불일 추출
+        LocalDate refundDate = findDateNearKeyword(normalized, "상장일|상장예정일|매매개시일");
+
+        // 상장일 추출
+        LocalDate listingDate = findDateNearKeyword(normalized, "상장일|상장예정일|매매개시일");
+
+        // 보호예수 해제일 또는 의무보유 해제일 추출
+        LocalDate lockupExpiryDate = findDateNearKeyword(
+                normalized,
+                "보호예수.*해제|의무보유.*해제|매각제한.*해제"
+        );
+
+        // 희망공모가 범위 추출
+        PriceRange offerPriceRange = findPriceRangeNearKeyword(
+                normalized,
+                "희망공모가|공모희망가|희망 공모가액"
+        );
+
+        // 확정공모가 추출
+        BigDecimal offerPrice = findMoneyNearKeyword(
+                normalized,
+                "확정공모가|확정 공모가|공모가액 확정|발행가액"
+        );
+
+        // 공모주식수 추출
+        Long shareCount = findShareCountNearKeyword(
+                normalized,
+                "공모주식수|모집주식수|공모 주식수|모집 주식수"
+        );
+
+        // 상장주식수 추출
+        Long totalListedShares = findShareCountNearKeyword(
+                normalized,
+                "상장예정주식수|상장주식수|상장 예정 주식수"
+        );
+
+        // 기관경쟁률 추출
+        BigDecimal institutionalCompetitionRate = findRateNearKeyword(
+                normalized,
+                "기관경쟁률|기관투자자.*경쟁률|수요예측.*경쟁률"
+        );
+
+        // 의무보유확약 비율 추출
+        BigDecimal lockupRatio = findPercentRatioNearKeyword(
+                normalized,
+                "의무보유확약|확약비율|의무보유 확약"
+        );
+
+        // 보호예수 비율 추출
+        BigDecimal protectiveCustodyRatio = findPercentRatioNearKeyword(
+                normalized,
+                "보호예수|매각제한|의무보유"
+        );
+
+        // 추출된 값들을 결과 DTO에 담아 반환
+        return IpoDisclosureParsingResult.builder()
+                .demandForecastStart(demandForecastRange.start())
+                .demandForecastEnd(demandForecastRange.end())
+                .refundDate(refundDate)
+                .listingDate(listingDate)
+                .lockupExpiryDate(lockupExpiryDate)
+                .offerPriceMin(offerPriceRange.min())
+                .offerPriceMax(offerPriceRange.max())
+                .offerPrice(offerPrice)
+                .shareCount(shareCount)
+                .totalListedShares(totalListedShares)
+                .institutionalCompetitionRate(institutionalCompetitionRate)
+                .lockupRatio(lockupRatio)
+                .protectiveCustodyRatio(protectiveCustodyRatio)
+                .build();
+    }
+
+    // 원문 공백을 정규화하는 메서드
+    private String normalize(String text) {
+        return text
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+
+
+
+    // 특정 키워드 근처에서 날짜 범위를 찾는 메서드
+    private DateRange findDateRangeNearKeyword(String text, String keywordRegex) {
+
+        // 키워드 뒤쪽 일정 범위 안에서 날짜 두 개를 찾는 정규식
+        Pattern pattern = Pattern.compile(
+                "(" + keywordRegex + ").{0,120}?(\\d{4}[.\\-/년 ]+\\d{1,2}[.\\-/월 ]+\\d{1,2}).{0,40}?(\\d{4}[.\\-/년 ]+\\d{1,2}[.\\-/월 ]+\\d{1,2})"
+        );
+
+        // 정규식을 text에 적용
+        Matcher matcher = pattern.matcher(text);
+
+        // 매칭되는 첫 번째 구간이 있으면 시작일과 종료일을 추출
+        if (matcher.find()) {
+
+            LocalDate start = ExternalDateParser.parseFlexibleDate(matcher.group(2));
+            LocalDate end = ExternalDateParser.parseFlexibleDate(matcher.group(3));
+
+            return new DateRange(start, end);
+
+        }
+
+        // 날짜 범위를 찾지 못하면 null 값으로 된 DateRange를 반환
+        return new DateRange(null, null);
+
+    }
+
+    // 특정 키워드 근처에서 날짜 하나를 찾는 메서드
+    private LocalDate findDateNearKeyword(String text, String keywordRegex) {
+
+        // 키워드 뒤쪽 120자 이내에서 날짜처럼 보이는 패턴을 찾음
+        Pattern pattern = Pattern.compile(
+                "(" + keywordRegex + ").{0,120}?(\\d{4}[.\\-/년 ]+\\d{1,2}[.\\-/월 ]+\\d{1,2})"
+        );
+
+        // 정규식을 text에 적용
+        Matcher matcher = pattern.matcher(text);
+
+        // 매칭되면 두 번째 그룹의 날짜 문자열을 LocalDate로 변환
+        if (matcher.find()) {
+            return ExternalDateParser.parseFlexibleDate(matcher.group(2));
+        }
+
+        // 찾지 못하면 null을 반환
+        return null;
+
+    }
+
+    // 특정 키워드 근처에서 금액 범위를 찾는 메서드
+
+    private PriceRange findPriceRangeNearKeyword(String text, String keywordRegex) {
+
+        Pattern pattern = Pattern.compile(
+                "(" + keywordRegex + ").{0,120}?([0-9,]+)\\s*원?.{0,20}?~.{0,20}?([0-9,]+)\\s*원?"
+        );
+
+        // 정규식을 text에 적용
+        Matcher matcher = pattern.matcher(text);
+
+        // 매칭되면 최소/최대 가격을 BigDecimal로 변환
+        if (matcher.find()) {
+
+            BigDecimal min = ExternalNumberParser.toBigDecimal(matcher.group(2));
+            BigDecimal max = ExternalNumberParser.toBigDecimal(matcher.group(3));
+
+            return new PriceRange(min, max);
+        }
+
+        // 찾지 못하면 null 범위를 반환
+        return new PriceRange(null, null);
+
+    }
+
+    // 특정 키워드 근처에서 단일 금액을 찾는 메서드
+    private BigDecimal findMoneyNearKeyword(String text, String keywordRegex) {
+
+
+        Pattern pattern = Pattern.compile(
+                "(" + keywordRegex + ").{0,120}?([0-9,]+)\\s*원"
+        );
+
+        // 정규식을 text에 적용
+        Matcher matcher = pattern.matcher(text);
+
+        if (matcher.find()) {
+            return ExternalNumberParser.toBigDecimal(matcher.group(2));
+        }
+
+        // 찾지 못하면 null을 반환
+        return null;
+    }
+
+    // 특정 키워드 근처에서 주식 수를 찾는 메서드
+    private Long findShareCountNearKeyword(String text, String keywordRegex) {
+
+        Pattern pattern = Pattern.compile(
+                "(" + keywordRegex + ").{0,120}?([0-9,]+)\\s*주"
+        );
+
+        // 정규식을 text에 적용
+        Matcher matcher = pattern.matcher(text);
+
+        // 매칭되면 주식 수 문자열을 Long으로 변환
+        if (matcher.find()) {
+            return ExternalNumberParser.toLong(matcher.group(2));
+        }
+
+        // 찾지 못하면 null을 반환
+        return null;
+
+    }
+
+    // 특정 키워드 근처에서 경쟁률을 찾는 메서드
+    private BigDecimal findRateNearKeyword(String text, String keywordRegex) {
+
+        Pattern pattern = Pattern.compile(
+                "(" + keywordRegex + ").{0,120}?([0-9,]+(?:\\.\\d+)?)\\s*[:대]?\\s*1"
+        );
+
+        // 정규식을 text에 적용
+        Matcher matcher = pattern.matcher(text);
+
+        // 매칭되면 경쟁률 숫자 부분만 BigDecimal로 변환.
+        if (matcher.find()) {
+            return ExternalNumberParser.toBigDecimal(matcher.group(2));
+        }
+
+        // 찾지 못하면 null을 반환
+        return null;
+
+    }
+
+    // 특정 키워드 근처에서 퍼센트를 찾아 0~1 사이 비율로 변환하는 메서드
+    private BigDecimal findPercentRatioNearKeyword(String text, String keywordRegex) {
+
+        Pattern pattern = Pattern.compile(
+                "(" + keywordRegex + ").{0,160}?([0-9,]+(?:\\.\\d+)?)\\s*%"
+        );
+
+        // 정규식을 text에 적용합니다.
+        Matcher matcher = pattern.matcher(text);
+
+        // 매칭되지 않으면 null을 반환합
+        if (!matcher.find()) {
+            return null;
+        }
+
+        BigDecimal percent = ExternalNumberParser.toBigDecimal(matcher.group(2));
+
+        if (percent == null) {
+            return null;
+        }
+
+        // 15.3%를 0.1530처럼 DB 저장용 비율로 변경
+        return percent.divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP);
+    }
+
+    // 날짜 범위를 표현하는 내부 record
+    private record DateRange(LocalDate start, LocalDate end) {
+    }
+
+    // 가격 범위를 표현하는 내부 record
+    // 희망공모가 하단/상단처럼 두 값을 함께 다룰 때 사용
+    private record PriceRange(BigDecimal min, BigDecimal max) {
+    }
+}

--- a/src/main/java/com/gong/modu/service/pipeline/IpoDisclosureTextParser.java
+++ b/src/main/java/com/gong/modu/service/pipeline/IpoDisclosureTextParser.java
@@ -1,6 +1,6 @@
 package com.gong.modu.service.pipeline;
 
-import com.gong.modu.domain.dto.IpoDisclosureParsingResult;
+import com.gong.modu.domain.dto.pipeline.IpoDisclosureParsingResult;
 import com.gong.modu.util.ExternalDateParser;
 import com.gong.modu.util.ExternalNumberParser;
 import org.springframework.stereotype.Component;
@@ -8,16 +8,29 @@ import org.springframework.stereotype.Component;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @Component
 // 공시 원문 텍스트에서 IPO 핵심값을 정규식 기반으로 추출하는 클래스
-// 텍스트에서 자주 등장하는 패턴을 우선 추출하는 1차 파서
+// 공시 문서는 같은 키워드와 숫자가 여러 번 반복되므로, 단순히 첫 번째 숫자를 잡지 않고 필드별 우선순위를 적용함
 public class IpoDisclosureTextParser {
+
+    // 날짜 패턴
+    // 예: 2021.07.26, 2021-07-26, 2021년 07월 26일 같은 형태를 잡기 위한 정규식
+    private static final String DATE_REGEX =
+            "\\d{4}\\s*[.\\-/년]\\s*\\d{1,2}\\s*[.\\-/월]\\s*\\d{1,2}\\s*(?:일)?";
+
+    // 금액/수량 숫자 패턴
+    private static final String NUMBER_REGEX =
+            "[0-9]{1,3}(?:,[0-9]{3})+|[0-9]+";
 
     // 원문 텍스트를 받아 파싱 결과 DTO로 변환하는 메서드
     public IpoDisclosureParsingResult parse(String text) {
+
+        // 원문이 없으면 모든 필드가 null인 결과를 반환
         if (text == null || text.isBlank()) {
             return IpoDisclosureParsingResult.builder().build();
         }
@@ -25,63 +38,71 @@ public class IpoDisclosureTextParser {
         String normalized = normalize(text);
 
         // 수요예측일 범위 추출
-        DateRange demandForecastRange = findDateRangeNearKeyword(normalized, "수요예측");
+        DateRange demandForecastRange = findDateRangeByKeywords(
+                normalized,
+                List.of("수요예측일", "수요예측 기간", "수요예측")
+        );
 
         // 환불일 추출
-        LocalDate refundDate = findDateNearKeyword(normalized, "상장일|상장예정일|매매개시일");
+        LocalDate refundDate = findDateByKeywords(
+                normalized,
+                List.of("환불일", "환불기일", "청약증거금 환불", "납입 및 환불")
+        );
 
         // 상장일 추출
-        LocalDate listingDate = findDateNearKeyword(normalized, "환불일|환불기일|청약증거금.*환불|납입 및 환불");
-
-        // 보호예수 해제일 또는 의무보유 해제일 추출
-        LocalDate lockupExpiryDate = findDateNearKeyword(
+        LocalDate listingDate = findDateByKeywords(
                 normalized,
-                "보호예수.*해제|의무보유.*해제|매각제한.*해제"
+                List.of("상장일", "상장예정일", "상장 예정일", "매매개시일", "매매 개시일")
+        );
+
+        // 락업해제일 추출
+        LocalDate lockupExpiryDate = findDateByKeywords(
+                normalized,
+                List.of("보호예수 해제", "의무보유 해제", "매각제한 해제", "보호예수기간 만료", "의무보유기간 만료")
         );
 
         // 희망공모가 범위 추출
-        PriceRange offerPriceRange = findPriceRangeNearKeyword(
+        PriceRange offerPriceRange = findPriceRangeByKeywords(
                 normalized,
-                "희망공모가|공모희망가|희망 공모가액"
+                List.of("희망공모가", "희망 공모가", "공모희망가", "공모 희망가", "모집(매출)가액(예정)")
         );
 
         // 확정공모가 추출
-        BigDecimal offerPrice = findMoneyNearKeyword(
+        BigDecimal offerPrice = findMoneyByKeywords(
                 normalized,
-                "확정공모가|확정 공모가|공모가액 확정|발행가액"
+                List.of("확정공모가", "확정 공모가", "공모가액 확정", "모집(매출) 확정가액", "발행가액")
         );
 
         // 공모주식수 추출
-        Long shareCount = findShareCountNearKeyword(
-                normalized,
-                "공모주식수|모집주식수|공모 주식수|모집 주식수"
-        );
+        // 단순히 "주"가 붙은 숫자를 잡으면 우리사주조합 배정수량 등이 잡힐 수 있으므로 강한 키워드를 우선
+        Long shareCount = findShareCountByPriority(normalized);
 
-        // 상장주식수 추출
-        Long totalListedShares = findShareCountNearKeyword(
+        // 상장예정주식수 추출
+        Long totalListedShares = findShareCountByKeywords(
                 normalized,
-                "상장예정주식수|상장주식수|상장 예정 주식수"
+                List.of("상장예정주식수", "상장 예정 주식수", "상장주식수", "상장 주식수")
         );
 
         // 기관경쟁률 추출
-        BigDecimal institutionalCompetitionRate = findRateNearKeyword(
+        // "37.92%" 같은 비율이 경쟁률로 잘못 잡히지 않도록 ":1", "대 1" 형태를 우선
+        BigDecimal institutionalCompetitionRate = findCompetitionRateByKeywords(
                 normalized,
-                "기관경쟁률|기관투자자.*경쟁률|수요예측.*경쟁률"
+                List.of("기관경쟁률", "기관투자자 경쟁률", "수요예측 경쟁률", "수요예측 결과", "경쟁률")
         );
 
         // 의무보유확약 비율 추출
-        BigDecimal lockupRatio = findPercentRatioNearKeyword(
+        BigDecimal lockupRatio = findPercentRatioByKeywords(
                 normalized,
-                "의무보유확약|확약비율|의무보유 확약"
+                List.of("의무보유확약 비율", "의무보유 확약 비율", "의무보유확약", "확약비율")
         );
 
-        // 보호예수 비율 추출
-        BigDecimal protectiveCustodyRatio = findPercentRatioNearKeyword(
+        // 락업 비율 추출
+        BigDecimal protectiveCustodyRatio = findPercentRatioByKeywords(
                 normalized,
-                "보호예수|매각제한|의무보유"
+                List.of("보호예수 비율", "보호예수", "매각제한 비율", "매각제한")
         );
 
-        // 추출된 값들을 결과 DTO에 담아 반환
+        // 추출된 값들을 DTO에 담아 반환
         return IpoDisclosureParsingResult.builder()
                 .demandForecastStart(demandForecastRange.start())
                 .demandForecastEnd(demandForecastRange.end())
@@ -99,169 +120,276 @@ public class IpoDisclosureTextParser {
                 .build();
     }
 
-    // 원문 공백을 정규화하는 메서드
+    // 공시 원문 공백을 정리하는 메서드
     private String normalize(String text) {
         return text
+                .replace("&cr;", "\n")
                 .replaceAll("\\s+", " ")
                 .trim();
     }
 
+    // 여러 키워드 후보를 순서대로 검사해서 날짜 범위를 찾는 메서드
+    private DateRange findDateRangeByKeywords(String text, List<String> keywords) {
 
+        // 키워드를 하나씩 검사
+        for (String keyword : keywords) {
 
-    // 특정 키워드 근처에서 날짜 범위를 찾는 메서드
-    private DateRange findDateRangeNearKeyword(String text, String keywordRegex) {
+            // 현재 키워드 주변 텍스트 조각들을 가져옴
+            List<String> windows = findWindows(text, keyword, 500);
 
-        // 키워드 뒤쪽 일정 범위 안에서 날짜 두 개를 찾는 정규식
-        Pattern pattern = Pattern.compile(
-                "(" + keywordRegex + ").{0,120}?(\\d{4}[.\\-/년 ]+\\d{1,2}[.\\-/월 ]+\\d{1,2}).{0,40}?(\\d{4}[.\\-/년 ]+\\d{1,2}[.\\-/월 ]+\\d{1,2})"
-        );
+            // 각 window 안에서 날짜 2개를 찾음
+            for (String window : windows) {
 
-        // 정규식을 text에 적용
-        Matcher matcher = pattern.matcher(text);
+                Pattern pattern = Pattern.compile(
+                        "(" + DATE_REGEX + ").{0,120}?(?:~|-|부터|에서).{0,120}?(" + DATE_REGEX + ")"
+                );
 
-        // 매칭되는 첫 번째 구간이 있으면 시작일과 종료일을 추출
-        if (matcher.find()) {
+                Matcher matcher = pattern.matcher(window);
 
-            LocalDate start = ExternalDateParser.parseFlexibleDate(matcher.group(2));
-            LocalDate end = ExternalDateParser.parseFlexibleDate(matcher.group(3));
+                if (matcher.find()) {
+                    LocalDate start = ExternalDateParser.parseFlexibleDate(matcher.group(1));
+                    LocalDate end = ExternalDateParser.parseFlexibleDate(matcher.group(2));
 
-            return new DateRange(start, end);
-
+                    return new DateRange(start, end);
+                }
+            }
         }
 
-        // 날짜 범위를 찾지 못하면 null 값으로 된 DateRange를 반환
         return new DateRange(null, null);
-
     }
 
-    // 특정 키워드 근처에서 날짜 하나를 찾는 메서드
-    private LocalDate findDateNearKeyword(String text, String keywordRegex) {
+    // 여러 키워드 후보를 순서대로 검사해서 날짜 하나를 찾는 메서드
+    private LocalDate findDateByKeywords(String text, List<String> keywords) {
 
-        // 키워드 뒤쪽 120자 이내에서 날짜처럼 보이는 패턴을 찾음
-        Pattern pattern = Pattern.compile(
-                "(" + keywordRegex + ").{0,120}?(\\d{4}[.\\-/년 ]+\\d{1,2}[.\\-/월 ]+\\d{1,2})"
-        );
+        for (String keyword : keywords) {
+            List<String> windows = findWindows(text, keyword, 500);
 
-        // 정규식을 text에 적용
-        Matcher matcher = pattern.matcher(text);
+            for (String window : windows) {
+                Matcher matcher = Pattern.compile(DATE_REGEX).matcher(window);
 
-        // 매칭되면 두 번째 그룹의 날짜 문자열을 LocalDate로 변환
-        if (matcher.find()) {
-            return ExternalDateParser.parseFlexibleDate(matcher.group(2));
+                if (matcher.find()) {
+                    return ExternalDateParser.parseFlexibleDate(matcher.group());
+                }
+            }
         }
 
-        // 찾지 못하면 null을 반환
         return null;
-
     }
 
-    // 특정 키워드 근처에서 금액 범위를 찾는 메서드
+    // 여러 키워드 후보를 순서대로 검사해서 가격 범위를 찾는 메서드입니다.
+    private PriceRange findPriceRangeByKeywords(String text, List<String> keywords) {
 
-    private PriceRange findPriceRangeNearKeyword(String text, String keywordRegex) {
+        for (String keyword : keywords) {
+            List<String> windows = findWindows(text, keyword, 500);
 
-        Pattern pattern = Pattern.compile(
-                "(" + keywordRegex + ").{0,120}?([0-9,]+)\\s*원?.{0,20}?~.{0,20}?([0-9,]+)\\s*원?"
-        );
+            for (String window : windows) {
+                Pattern pattern = Pattern.compile(
+                        "(" + NUMBER_REGEX + ")\\s*원?.{0,80}?(?:~|-|부터|에서).{0,80}?(" + NUMBER_REGEX + ")\\s*원?"
+                );
 
-        // 정규식을 text에 적용
-        Matcher matcher = pattern.matcher(text);
+                Matcher matcher = pattern.matcher(window);
 
-        // 매칭되면 최소/최대 가격을 BigDecimal로 변환
-        if (matcher.find()) {
+                if (matcher.find()) {
+                    BigDecimal min = ExternalNumberParser.toBigDecimal(matcher.group(1));
+                    BigDecimal max = ExternalNumberParser.toBigDecimal(matcher.group(2));
 
-            BigDecimal min = ExternalNumberParser.toBigDecimal(matcher.group(2));
-            BigDecimal max = ExternalNumberParser.toBigDecimal(matcher.group(3));
-
-            return new PriceRange(min, max);
+                    return new PriceRange(min, max);
+                }
+            }
         }
 
-        // 찾지 못하면 null 범위를 반환
         return new PriceRange(null, null);
-
     }
 
-    // 특정 키워드 근처에서 단일 금액을 찾는 메서드
-    private BigDecimal findMoneyNearKeyword(String text, String keywordRegex) {
+    // 여러 키워드 후보를 순서대로 검사해서 단일 금액을 찾는 메서드
+    private BigDecimal findMoneyByKeywords(String text, List<String> keywords) {
 
+        for (String keyword : keywords) {
+            List<String> windows = findWindows(text, keyword, 500);
 
-        Pattern pattern = Pattern.compile(
-                "(" + keywordRegex + ").{0,120}?([0-9,]+)\\s*원"
-        );
+            for (String window : windows) {
+                Pattern pattern = Pattern.compile("(" + NUMBER_REGEX + ")\\s*원");
 
-        // 정규식을 text에 적용
-        Matcher matcher = pattern.matcher(text);
+                Matcher matcher = pattern.matcher(window);
 
-        if (matcher.find()) {
-            return ExternalNumberParser.toBigDecimal(matcher.group(2));
+                if (matcher.find()) {
+                    return ExternalNumberParser.toBigDecimal(matcher.group(1));
+                }
+            }
         }
 
-        // 찾지 못하면 null을 반환
         return null;
     }
 
-    // 특정 키워드 근처에서 주식 수를 찾는 메서드
-    private Long findShareCountNearKeyword(String text, String keywordRegex) {
+    // 공모주식수를 우선순위 기반으로 찾는 메서드
+    private Long findShareCountByPriority(String text) {
 
-        Pattern pattern = Pattern.compile(
-                "(" + keywordRegex + ").{0,120}?([0-9,]+)\\s*주"
+        // 1순위: 공시 앞부분의 "모집 또는 매출 증권의 종류 : 기명식 보통주 65,450,000주" 같은 문구입니다.
+        Long fromSecurityType = findShareCountByKeywords(
+                text,
+                List.of("모집 또는 매출 증권의 종류", "모집 또는 매출할 증권의 종류", "모집매출 증권의 종류")
         );
 
-        // 정규식을 text에 적용
-        Matcher matcher = pattern.matcher(text);
-
-        // 매칭되면 주식 수 문자열을 Long으로 변환
-        if (matcher.find()) {
-            return ExternalNumberParser.toLong(matcher.group(2));
+        if (fromSecurityType != null) {
+            return fromSecurityType;
         }
 
-        // 찾지 못하면 null을 반환
-        return null;
+        // 2순위: 명시적인 공모주식수 표현
+        Long fromOfferingKeyword = findShareCountByKeywords(
+                text,
+                List.of("공모주식수", "공모 주식수", "모집주식수", "모집 주식수", "모집(매출) 주식수")
+        );
 
+        if (fromOfferingKeyword != null) {
+            return fromOfferingKeyword;
+        }
+
+        // 3순위: 모집/매출 수량 표현
+        return findShareCountByKeywords(
+                text,
+                List.of("모집수량", "매출수량", "모집 수량", "매출 수량")
+        );
     }
 
-    // 특정 키워드 근처에서 경쟁률을 찾는 메서드
-    private BigDecimal findRateNearKeyword(String text, String keywordRegex) {
+    // 여러 키워드 후보를 순서대로 검사해서 주식 수를 찾는 메서드
+    private Long findShareCountByKeywords(String text, List<String> keywords) {
 
-        Pattern pattern = Pattern.compile(
-                "(" + keywordRegex + ").{0,120}?([0-9,]+(?:\\.\\d+)?)\\s*[:대]?\\s*1"
-        );
+        for (String keyword : keywords) {
+            List<String> windows = findWindows(text, keyword, 600);
 
-        // 정규식을 text에 적용
-        Matcher matcher = pattern.matcher(text);
+            Long bestCandidate = null;
 
-        // 매칭되면 경쟁률 숫자 부분만 BigDecimal로 변환.
-        if (matcher.find()) {
-            return ExternalNumberParser.toBigDecimal(matcher.group(2));
+            for (String window : windows) {
+                Pattern pattern = Pattern.compile("(" + NUMBER_REGEX + ")\\s*주");
+
+                Matcher matcher = pattern.matcher(window);
+
+                while (matcher.find()) {
+                    Long value = ExternalNumberParser.toLong(matcher.group(1));
+
+                    if (value == null) {
+                        continue;
+                    }
+
+                    // 같은 window 안에서 여러 후보가 나오면 더 큰 값을 우선합니다.
+                    // 공모주식수는 우리사주/기관/일반 배정 물량보다 전체 수량이 더 큰 경우가 많기 때문입니다.
+                    if (bestCandidate == null || value > bestCandidate) {
+                        bestCandidate = value;
+                    }
+                }
+            }
+
+            if (bestCandidate != null) {
+                return bestCandidate;
+            }
         }
 
-        // 찾지 못하면 null을 반환
         return null;
-
     }
 
-    // 특정 키워드 근처에서 퍼센트를 찾아 0~1 사이 비율로 변환하는 메서드
-    private BigDecimal findPercentRatioNearKeyword(String text, String keywordRegex) {
+    // 여러 키워드 후보를 순서대로 검사해서 기관경쟁률을 찾는 메서드
+    private BigDecimal findCompetitionRateByKeywords(String text, List<String> keywords) {
 
-        Pattern pattern = Pattern.compile(
-                "(" + keywordRegex + ").{0,160}?([0-9,]+(?:\\.\\d+)?)\\s*%"
-        );
+        for (String keyword : keywords) {
+            List<String> windows = findWindows(text, keyword, 700);
 
-        // 정규식을 text에 적용합니다.
-        Matcher matcher = pattern.matcher(text);
+            BigDecimal bestCandidate = null;
 
-        // 매칭되지 않으면 null을 반환합
-        if (!matcher.find()) {
-            return null;
+            for (String window : windows) {
+
+                // 1732.83:1, 1732.83 대 1, 1,732.83:1 같은 형태를 찾습니다.
+                Pattern pattern = Pattern.compile(
+                        "(" + NUMBER_REGEX + "(?:\\.\\d+)?)\\s*(?:[:：]|대)\\s*1"
+                );
+
+                Matcher matcher = pattern.matcher(window);
+
+                while (matcher.find()) {
+                    BigDecimal value = ExternalNumberParser.toBigDecimal(matcher.group(1));
+
+                    if (value == null) {
+                        continue;
+                    }
+
+                    // 경쟁률 후보가 여러 개면 더 큰 값을 우선합니다.
+                    // 의무보유확약 비율처럼 작은 수치가 잘못 잡히는 것을 줄이기 위한 선택입니다.
+                    if (bestCandidate == null || value.compareTo(bestCandidate) > 0) {
+                        bestCandidate = value;
+                    }
+                }
+            }
+
+            if (bestCandidate != null) {
+                return bestCandidate;
+            }
         }
 
-        BigDecimal percent = ExternalNumberParser.toBigDecimal(matcher.group(2));
+        return null;
+    }
 
-        if (percent == null) {
-            return null;
+    // 여러 키워드 후보를 순서대로 검사해서 퍼센트 값을 0~1 비율로 변환하는 메서드
+    private BigDecimal findPercentRatioByKeywords(String text, List<String> keywords) {
+
+        for (String keyword : keywords) {
+            List<String> windows = findWindows(text, keyword, 700);
+
+            BigDecimal bestPercent = null;
+
+            for (String window : windows) {
+                Pattern pattern = Pattern.compile("(" + NUMBER_REGEX + "(?:\\.\\d+)?)\\s*%");
+
+                Matcher matcher = pattern.matcher(window);
+
+                while (matcher.find()) {
+                    BigDecimal percent = ExternalNumberParser.toBigDecimal(matcher.group(1));
+
+                    if (percent == null) {
+                        continue;
+                    }
+
+                    // 같은 영역에서 여러 퍼센트가 있으면 가장 큰 값을 우선합니다.
+                    // 공시 표에서 신청수량/건수/비율이 같이 나올 때 대표 비율을 잡기 위한 단순 전략입니다.
+                    if (bestPercent == null || percent.compareTo(bestPercent) > 0) {
+                        bestPercent = percent;
+                    }
+                }
+            }
+
+            if (bestPercent != null) {
+                return bestPercent.divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP);
+            }
         }
 
-        // 15.3%를 0.1530처럼 DB 저장용 비율로 변경
-        return percent.divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP);
+        return null;
+    }
+
+    // 특정 키워드가 등장하는 위치 주변의 문자열 조각들을 반환하는 메서드
+    private List<String> findWindows(String text, String keyword, int windowSize) {
+
+        List<String> windows = new ArrayList<>();
+
+        if (text == null || text.isBlank() || keyword == null || keyword.isBlank()) {
+            return windows;
+        }
+
+        int fromIndex = 0;
+
+        while (fromIndex < text.length()) {
+            int keywordIndex = text.indexOf(keyword, fromIndex);
+
+            if (keywordIndex < 0) {
+                break;
+            }
+
+            int start = Math.max(0, keywordIndex - 100);
+            int end = Math.min(text.length(), keywordIndex + windowSize);
+
+            windows.add(text.substring(start, end));
+
+            fromIndex = keywordIndex + keyword.length();
+        }
+
+        return windows;
     }
 
     // 날짜 범위를 표현하는 내부 record
@@ -269,7 +397,6 @@ public class IpoDisclosureTextParser {
     }
 
     // 가격 범위를 표현하는 내부 record
-    // 희망공모가 하단/상단처럼 두 값을 함께 다룰 때 사용
     private record PriceRange(BigDecimal min, BigDecimal max) {
     }
 }

--- a/src/main/java/com/gong/modu/util/RedisUtil.java
+++ b/src/main/java/com/gong/modu/util/RedisUtil.java
@@ -16,6 +16,9 @@ public class RedisUtil {
     private static final String EMAIL_CODE_PREFIX = "email:code:";
     private static final String EMAIL_VERIFIED_PREFIX = "email:verified:";
 
+    private static final String DISCLOSURE_PARSE_LOCK_PREFIX = "lock:disclosure-parse:";
+    private static final String DISCLOSURE_PARSE_FAILED_PREFIX = "failed:disclosure-parse:";
+
     // 이메일 인증코드 저장 (TTL: 초 단위)
     public void saveEmailCode(String email, String code, long ttlSeconds) {
         redisTemplate.opsForValue()
@@ -79,5 +82,42 @@ public class RedisUtil {
     // 블랙리스트 여부 확인
     public boolean isBlacklisted(String accessToken) {
         return redisTemplate.hasKey(BLACKLIST_PREFIX + accessToken);
+    }
+
+    // 특정 공시 접수번호에 대해 파싱 lock을 획득
+    public boolean tryLockDisclosureParsing(String rceptNo, long ttlMinutes) {
+        Boolean result = redisTemplate.opsForValue()
+                .setIfAbsent(
+                        DISCLOSURE_PARSE_LOCK_PREFIX + rceptNo,
+                        "locked",
+                        Duration.ofMinutes(ttlMinutes)
+                );
+
+        return Boolean.TRUE.equals(result);
+    }
+
+    // 특정 공시 접수번호의 파싱 lock을 해제
+    // 파싱 성공 또는 실패 후 lock을 제거해 다음 실행에서 다시 처리 가능하게 함
+    public void unlockDisclosureParsing(String rceptNo) {
+        redisTemplate.delete(DISCLOSURE_PARSE_LOCK_PREFIX + rceptNo);
+    }
+
+    // 특정 공시 접수번호의 파싱 실패 기록을 저장
+    // 실패한 공시를 너무 자주 재시도하면 DART 호출과 서버 자원을 낭비하므로 짧게 막아둠
+    public void markDisclosureParsingFailed(String rceptNo, long ttlHours) {
+        redisTemplate.opsForValue()
+                .set(
+                        DISCLOSURE_PARSE_FAILED_PREFIX + rceptNo,
+                        "failed",
+                        Duration.ofHours(ttlHours)
+                );
+    }
+
+    // 특정 공시 접수번호가 최근 파싱 실패 상태인지 확인
+    // 실패 상태라면 이번 스케줄러에서는 건너뜀
+    public boolean isDisclosureParsingRecentlyFailed(String rceptNo) {
+        return Boolean.TRUE.equals(
+                redisTemplate.hasKey(DISCLOSURE_PARSE_FAILED_PREFIX + rceptNo)
+        );
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #30 

## 📝 작업 내용

### 1. DART 공시 원문 ZIP 다운로드 로직 추가

- DART 공시서류원본파일 API(`/api/document.xml`)을 호출하여 `rceptNo` 기준으로 공시 원문 ZIP 파일을 다운로드하는 메서드를 추가했습니다.

- 기존 JSON 응답 DTO 방식과 달리 ZIP 파일은 바이너리 응답이므로 `byte[]` 형태로 응답을 받도록 구현했습니다.

- 응답이 비어 있거나 DART 호출 중 오류가 발생하는 경우 기존 `CustomException` 기반 에러 처리 흐름을 따르도록 구성했습니다.

### 2. 공시 원문 텍스트 추출 로직 추가

- DART에서 내려받은 ZIP 파일 내부의 XML, HTML, HTM, TXT 파일을 읽어 하나의 원문 텍스트로 추출하는 로직을 추가했습니다.

- HTML/XML 태그, script/style 영역, 불필요한 공백을 정리하여 이후 정규식 파싱이 가능하도록 텍스트를 정규화했습니다.

- UTF-8 디코딩을 우선 적용하고, 깨진 문자가 많은 경우 MS949로 재시도하도록 처리했습니다.


### 3. 공시 원문 기반 IPO 핵심값 파싱 로직 추가

- 공시 원문 텍스트에서 공모주 상세 화면에 필요한 일부 값을 정규식 기반으로 추출하는 파서를 추가했습니다.

- 파싱 대상 값은 다음과 같습니다.

  - 수요예측일

  - 환불일

  - 상장일

  - 보호예수/락업 해제일

  - 희망공모가

  - 확정공모가

  - 공모주식수

  - 상장주식수

  - 기관경쟁률

  - 의무보유확약 비율

  - 보호예수 비율

### 4. 파싱 결과 DB 반영 로직 추가

- 파싱 결과를 기존 공모주 도메인 테이블에 반영하도록 구현했습니다.

- 반영 대상 테이블은 다음과 같습니다.

  - `ipo_events`

    - 수요예측일, 환불일, 상장일, 락업해제일 보강

  - `ipo_offerings`

    - 희망공모가, 확정공모가, 공모주식수, 상장주식수 보강

  - `ipo_metrics`

    - 기관경쟁률, 의무보유확약 비율, 보호예수 비율 보강

  - `ipo_disclosure_reports`

    - 추출된 공시 원문 텍스트 저장

### 5. 미파싱 공시 대상 스케줄러 추가

- `original_text`가 아직 없는 공시만 조회하여 원문 ZIP 다운로드 및 파싱을 수행하도록 스케줄러를 추가했습니다.

- 매번 모든 공시를 다시 다운로드하지 않고, 아직 파싱되지 않은 공시만 처리하도록 하여 불필요한 API 호출과 서버 부하를 줄였습니다.

- 한 번에 처리할 수 있는 공시 개수를 제한하여 ZIP 다운로드/파싱 작업이 과도하게 실행되지 않도록 했습니다.

### 6. Redis 기반 중복 파싱 방지 로직 추가

- 동일한 `rceptNo`에 대해 중복 파싱이 동시에 실행되지 않도록 Redis lock을 적용했습니다.

- 파싱 실패 공시는 일정 시간 동안 재시도를 막아 반복 실패로 인한 API 호출 낭비를 줄였습니다.

- ZIP 원문 자체를 Redis에 저장하지 않고, Redis는 중복 실행 방지와 실패 재시도 제어 용도로만 사용했습니다.

## 🧪 검증

### parser 성능 텍스트
<img width="2094" height="1564" alt="image" src="https://github.com/user-attachments/assets/555745aa-f35f-413a-8cde-2a20eafb03c9" />

### DART ZIP 다운로드+파싱 테스트
<img width="2006" height="1476" alt="image" src="https://github.com/user-attachments/assets/2c64f47d-67d0-41e6-b88a-5c0c28e0e227" />


## ℹ️ 참고사항
- 공시 원문 파싱은 DART/KIS 기본 API만으로 채우기 어려운 공모주 상세 필드를 보강하기 위한 2차 데이터 수집 파이프라인입니다.
- 정규식 기반 파싱은 공시 문서 형식에 따라 일부 값이 누락될 수 있으므로, 이후 실제 공시 샘플을 추가로 확보하면서 파싱 패턴을 점진적으로 보완할 예정입니다.
- ZIP 파일 자체나 긴 원문 텍스트는 Redis에 저장하지 않고 PostgreSQL의 original_text에 저장합니다.
- 추후 원문 크기가 커질 경우 S3 저장 후 DB에는 파일 URL만 저장하는 구조로 확장할 수 있습니다.