### PR TITLE
Feat: 공모주 파싱 로직 수정 & 청약이력, 관심공모주 기능 구현

### DIFF
--- a/src/main/java/com/gong/modu/config/AsyncConfig.java
+++ b/src/main/java/com/gong/modu/config/AsyncConfig.java
@@ -22,4 +22,17 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    // 공시 원문 ZIP 다운로드 + Claude API 호출이 모두 네트워크 I/O이므로 병렬 처리로 속도 개선
+    // Claude API rate limit을 고려해 스레드 수를 5개로 제한
+    @Bean("disclosureParsingPool")
+    public Executor disclosureParsingPool() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("disclosure-parsing-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/gong/modu/controller/InterestIpoController.java
+++ b/src/main/java/com/gong/modu/controller/InterestIpoController.java
@@ -1,0 +1,50 @@
+package com.gong.modu.controller;
+
+import com.gong.modu.domain.dto.user.InterestIpoItemResponse;
+import com.gong.modu.service.user.InterestIpoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Tag(name = "InterestIpo", description = "관심 공모주(찜) 관리 - 기능명세서 5.1.2")
+@RestController
+@RequestMapping("/api/interest-ipos")
+@RequiredArgsConstructor
+public class InterestIpoController {
+
+    private final InterestIpoService interestIpoService;
+
+    @Operation(summary = "관심 공모주 등록")
+    @PostMapping("/{ipoEventId}")
+    public ResponseEntity<Map<String, Long>> addInterest(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long ipoEventId
+    ) {
+        Long interestId = interestIpoService.addInterest(userId, ipoEventId);
+        return ResponseEntity.ok(Map.of("interestId", interestId));
+    }
+
+    @Operation(summary = "관심 공모주 해제")
+    @DeleteMapping("/{ipoEventId}")
+    public ResponseEntity<Void> removeInterest(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long ipoEventId
+    ) {
+        interestIpoService.removeInterest(userId, ipoEventId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "내 관심 공모주 목록 조회")
+    @GetMapping
+    public ResponseEntity<List<InterestIpoItemResponse>> getMyInterests(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ResponseEntity.ok(interestIpoService.getMyInterests(userId));
+    }
+}

--- a/src/main/java/com/gong/modu/controller/IpoController.java
+++ b/src/main/java/com/gong/modu/controller/IpoController.java
@@ -1,14 +1,18 @@
 package com.gong.modu.controller;
 
 import com.gong.modu.domain.dto.ipo.IpoDisclosureReportResponse;
+import com.gong.modu.domain.dto.ipo.IpoEventSearchItemResponse;
 import com.gong.modu.domain.dto.ipo.IpoFinancialResponse;
 import com.gong.modu.domain.dto.ipo.IpoHomeItemResponse;
 import com.gong.modu.domain.enums.ipo.IpoScheduleFilter;
 import com.gong.modu.service.ipo.IpoDisclosureReportQueryService;
 import com.gong.modu.service.ipo.IpoFinancialQueryService;
 import com.gong.modu.service.ipo.IpoHomeQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Ipo", description = "공모주 일정/검색 (3.1.1 청약 일정 리스트업, 4.2 종목 검색)")
 @RestController
 @RequestMapping("/api/ipo")
 @RequiredArgsConstructor
@@ -26,13 +31,52 @@ public class IpoController {
     private final IpoFinancialQueryService financialQueryService;
     private final IpoHomeQueryService homeQueryService;
 
-    // 홈 화면 청약 일정 리스트 조회 (필터 기준 일정일 최근 3개월~향후 4주)
-    // filter: 수요예측/청약/락업해제/환불/상장/배정 (기본값 청약)
+    @Operation(
+            summary = "홈 화면 청약 일정 리스트 조회",
+            description = """
+                    필터 기준 일정일이 최근 3개월 ~ 향후 4주 범위에 드는 공모주를 일정일 순으로 반환합니다.
+
+                    필터 종류:
+                    - `SUBSCRIPTION` (기본값) — 일반 투자자 청약일 기준
+                    - `DEMAND_FORECAST` — 기관 수요예측일 기준
+                    - `LOCKUP_EXPIRY` — 보호예수 해제일 기준
+                    - `REFUND` — 환불일 기준
+                    - `LISTING` — 상장일 기준
+                    - `ALLOCATION` — 배정일 기준
+
+                    응답 필드 참고:
+                    - `listingDate` / `lockupExpiryDate`가 백엔드 추정값이면 `listingDateEstimated` / `lockupExpiryDateEstimated`가 `true`로 내려옵니다.
+                    - `signalLevel`이 null이면 `signalUnavailableReason`에 사유(SPAC / PRE_DEMAND_FORECAST / INCOMPLETE_DATA)가 채워집니다.
+                        - SPAC                    → 스팩이라 수요예측 자체 없음 (정상)
+                        - PRE_DEMAND_FORECAST     → 수요예측 전 (지표 곧 채워질 예정)
+                        - INCOMPLETE_DATA         → 수요예측 후인데 AI가 지표 추출 실패 (재파싱 필요)
+                    - 로그인 사용자만 `favorited`가 정확히 반영되며, 비로그인은 모두 false.
+                    """
+    )
     @GetMapping("/home")
     public ResponseEntity<List<IpoHomeItemResponse>> getHomeSchedule(
-            @RequestParam(defaultValue = "SUBSCRIPTION") IpoScheduleFilter filter
+            @RequestParam(defaultValue = "SUBSCRIPTION") IpoScheduleFilter filter,
+            @AuthenticationPrincipal Long userId
     ) {
-        return ResponseEntity.ok(homeQueryService.getHomeSchedule(filter));
+        return ResponseEntity.ok(homeQueryService.getHomeSchedule(filter, userId));
+    }
+
+    @Operation(
+            summary = "회사명 키워드로 공모주 검색",
+            description = """
+                    회사명에 키워드가 포함된 공모 이벤트를 최대 **20건**까지 최신순으로 반환합니다.
+
+                    용도: 청약이력 4.2 "현재 청약 중 이력" 등록 시 사용자가 자신이 청약한 종목을 선택하는 검색창에서 사용합니다.
+                    선택한 응답의 `ipoEventId`를 `POST /api/subscription-history/ongoing` 의 `ipoEventId` 필드로 넘기면 됩니다.
+
+                    검색은 대소문자 구분 없이 부분 일치합니다. 빈 키워드는 빈 배열을 반환합니다.
+                    """
+    )
+    @GetMapping("/search")
+    public ResponseEntity<List<IpoEventSearchItemResponse>> searchIpoEvents(
+            @RequestParam String keyword
+    ) {
+        return ResponseEntity.ok(homeQueryService.searchIpoEvents(keyword));
     }
 
     @GetMapping("/{ipoEventId}/disclosure")

--- a/src/main/java/com/gong/modu/controller/SubscriptionHistoryController.java
+++ b/src/main/java/com/gong/modu/controller/SubscriptionHistoryController.java
@@ -1,0 +1,94 @@
+package com.gong.modu.controller;
+
+import com.gong.modu.domain.dto.user.*;
+import com.gong.modu.domain.enums.ipo.SubscriptionRecordStatus;
+import com.gong.modu.service.user.SubscriptionHistoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Tag(name = "SubscriptionHistory", description = "청약 이력 관리 (4.1 과거 투자 이력 + 4.2 현재 청약 중 이력)")
+@RestController
+@RequestMapping("/api/subscription-history")
+@RequiredArgsConstructor
+public class SubscriptionHistoryController {
+
+    private final SubscriptionHistoryService historyService;
+
+    @Operation(summary = "4.1 과거 투자 이력 생성 (DB 종목 조회 없이 사용자 직접 입력, COMPLETED)")
+    @PostMapping("/completed")
+    public ResponseEntity<Map<String, Long>> createCompleted(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid CompletedHistoryCreateRequest request
+    ) {
+        Long id = historyService.createCompleted(userId, request);
+        return ResponseEntity.ok(Map.of("id", id));
+    }
+
+    @Operation(summary = "4.2 현재 청약 중 이력 생성 (IpoEvent 연결 필수, ONGOING)")
+    @PostMapping("/ongoing")
+    public ResponseEntity<Map<String, Long>> createOngoing(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid OngoingHistoryCreateRequest request
+    ) {
+        Long id = historyService.createOngoing(userId, request);
+        return ResponseEntity.ok(Map.of("id", id));
+    }
+
+    @Operation(summary = "내 청약 이력 조회 (status 미지정 시 전체)")
+    @GetMapping
+    public ResponseEntity<List<SubscriptionHistoryResponse>> getMyHistories(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) SubscriptionRecordStatus status
+    ) {
+        return ResponseEntity.ok(historyService.getMyHistories(userId, status));
+    }
+
+    @Operation(summary = "청약 이력 단건 조회")
+    @GetMapping("/{historyId}")
+    public ResponseEntity<SubscriptionHistoryResponse> getHistory(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long historyId
+    ) {
+        return ResponseEntity.ok(historyService.getHistory(userId, historyId));
+    }
+
+    @Operation(summary = "청약 이력 수정 (null 필드는 기존 값 유지)")
+    @PatchMapping("/{historyId}")
+    public ResponseEntity<Void> updateHistory(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long historyId,
+            @RequestBody @Valid SubscriptionHistoryUpdateRequest request
+    ) {
+        historyService.updateHistory(userId, historyId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "ONGOING 이력을 매도 정보 입력으로 COMPLETED 전환")
+    @PostMapping("/{historyId}/complete")
+    public ResponseEntity<Void> completeHistory(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long historyId,
+            @RequestBody @Valid CompleteHistoryRequest request
+    ) {
+        historyService.completeHistory(userId, historyId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "청약 이력 삭제")
+    @DeleteMapping("/{historyId}")
+    public ResponseEntity<Void> deleteHistory(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long historyId
+    ) {
+        historyService.deleteHistory(userId, historyId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/gong/modu/controller/test/DisclosureParserTestController.java
+++ b/src/main/java/com/gong/modu/controller/test/DisclosureParserTestController.java
@@ -2,6 +2,7 @@ package com.gong.modu.controller.test;
 
 import com.gong.modu.client.DartApiClient;
 import com.gong.modu.domain.dto.dart.DartDisclosureSearchResponse;
+import com.gong.modu.domain.dto.dart.DartEquitySecuritiesReportResponse;
 import com.gong.modu.domain.dto.pipeline.AiDisclosureParsingResult;
 import com.gong.modu.domain.dto.pipeline.IpoDisclosureParsingResult;
 import com.gong.modu.domain.dto.test.AiDisclosureParsingResponse;
@@ -9,7 +10,9 @@ import com.gong.modu.domain.dto.test.MultiDisclosureParsingResponse;
 import com.gong.modu.domain.dto.test.MultiDisclosureParsingResponse.PerDocumentResult;
 import com.gong.modu.domain.entity.ipo.IpoDisclosureReport;
 import com.gong.modu.domain.enums.ipo.DisclosureDocumentType;
+import com.gong.modu.domain.enums.ipo.IpoEventStatus;
 import com.gong.modu.repository.ipo.IpoDisclosureReportRepository;
+import com.gong.modu.repository.ipo.IpoEventRepository;
 import com.gong.modu.service.pipeline.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
@@ -46,6 +49,7 @@ public class DisclosureParserTestController {
 
     private final DartCompanySyncService dartCompanySyncService; // 기업개황 동기화 담당
     private final DartIpoSyncService dartIpoSyncService; // 공시/주요정보 IPO 데이터 동기화 담당
+    private final IpoEventRepository ipoEventRepository; // UPCOMING 일괄 재파싱용
 
 
     // 실제 DART rceptNo로 ZIP 다운로드, AI 파싱, 검증·변환 결과까지 확인하는 테스트 API
@@ -227,6 +231,8 @@ public class DisclosureParserTestController {
         return IpoDisclosureParsingResult.builder()
                 .demandForecastStart(pickFirst(results, IpoDisclosureParsingResult::getDemandForecastStart, "demandForecastStart", fieldSourceMap))
                 .demandForecastEnd(pickFirst(results, IpoDisclosureParsingResult::getDemandForecastEnd, "demandForecastEnd", fieldSourceMap))
+                .subscriptionStart(pickFirst(results, IpoDisclosureParsingResult::getSubscriptionStart, "subscriptionStart", fieldSourceMap))
+                .subscriptionEnd(pickFirst(results, IpoDisclosureParsingResult::getSubscriptionEnd, "subscriptionEnd", fieldSourceMap))
                 .refundDate(pickFirst(results, IpoDisclosureParsingResult::getRefundDate, "refundDate", fieldSourceMap))
                 .listingDate(pickFirst(results, IpoDisclosureParsingResult::getListingDate, "listingDate", fieldSourceMap))
                 .lockupExpiryDate(pickFirst(results, IpoDisclosureParsingResult::getLockupExpiryDate, "lockupExpiryDate", fieldSourceMap))
@@ -238,6 +244,7 @@ public class DisclosureParserTestController {
                 .institutionalCompetitionRate(pickFirst(results, IpoDisclosureParsingResult::getInstitutionalCompetitionRate, "institutionalCompetitionRate", fieldSourceMap))
                 .lockupRatio(pickFirst(results, IpoDisclosureParsingResult::getLockupRatio, "lockupRatio", fieldSourceMap))
                 .protectiveCustodyRatio(pickFirst(results, IpoDisclosureParsingResult::getProtectiveCustodyRatio, "protectiveCustodyRatio", fieldSourceMap))
+                .brokerNames(pickFirst(results, IpoDisclosureParsingResult::getBrokerNames, "brokerNames", fieldSourceMap))
                 .build();
     }
 
@@ -313,7 +320,7 @@ public class DisclosureParserTestController {
 
     // 아직 원문이 파싱되지 않은 공시를 ZIP 다운로드·AI 파싱하여 DB에 반영하는 테스트 API
     // 스케줄러 parseUnparsedDartDisclosureDocuments()를 수동으로 트리거하는 용도
-    // ZIP 다운로드와 AI 호출이 포함되므로 limit이 크면 응답이 느릴 수 있음
+    // limit은 한 번 호출에 파싱할 공시 건수 (ZIP 다운로드·AI 호출 포함이라 크면 느림)
     @PostMapping("/parse-unparsed")
     public ResponseEntity<Void> parseUnparsed(
             @RequestParam(defaultValue = "5") int limit
@@ -321,6 +328,37 @@ public class DisclosureParserTestController {
         dartDisclosureParsingService.parseUnparsedDisclosureReports(limit);
 
         return ResponseEntity.ok().build();
+    }
+
+    // 특정 기업의 estkRs(지분증권 증권신고서 주요정보) 원응답을 그대로 확인하는 진단용 테스트 API
+    // 청약기일 등이 sync 시 채워지지 않는 원인(데이터 없음/형식 등)을 파악하기 위함
+    @GetMapping("/equity-report/{corpCode}")
+    public ResponseEntity<Map<String, Object>> inspectEquityReport(
+            @PathVariable String corpCode,
+            @RequestParam(required = false) String beginDate,
+            @RequestParam(required = false) String endDate
+    ) {
+        LocalDate today = LocalDate.now();
+        String end = endDate != null ? endDate : today.format(BASIC_DATE);
+        String begin = beginDate != null ? beginDate : today.minusDays(120).format(BASIC_DATE);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("corpCode", corpCode);
+        result.put("beginDate", begin);
+        result.put("endDate", end);
+
+        try {
+            DartEquitySecuritiesReportResponse response =
+                    dartApiClient.getEquitySecuritiesReport(corpCode, begin, end);
+            result.put("dartStatus", response.getStatus());
+            result.put("dartMessage", response.getMessage());
+            result.put("itemCount", response.getList() == null ? 0 : response.getList().size());
+            result.put("items", response.getList());
+        } catch (Exception e) {
+            result.put("error", e.getMessage());
+        }
+
+        return ResponseEntity.ok(result);
     }
 
     // 실제 DART rceptNo로 ZIP 다운로드, 텍스트 추출, AI 파싱, DB 반영까지 수행하는 테스트 API
@@ -335,6 +373,90 @@ public class DisclosureParserTestController {
         dartDisclosureParsingService.parseDisclosureReport(ipoEventId, rceptNo);
 
         return ResponseEntity.ok().build();
+    }
+
+    // 특정 IpoEvent에 속한 모든 공시를 강제로 재파싱하는 테스트 API
+    // 컨텍스트 추출 로직이나 AI 프롬프트를 바꾼 뒤, 이미 original_text가 있는 공시도 다시 돌릴 때 사용
+    // rceptNo만 projection으로 조회해서 LOB(original_text) 로딩 시 트랜잭션 문제 회피
+    @PostMapping("/reparse-by-ipo/{ipoEventId}")
+    public ResponseEntity<Map<String, Object>> reparseByIpoEvent(
+            @PathVariable Long ipoEventId
+    ) {
+        List<String> rceptNos = disclosureReportRepository.findRceptNosByIpoEventId(ipoEventId);
+
+        List<String> reparsed = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+
+        for (String rceptNo : rceptNos) {
+            try {
+                dartDisclosureParsingService.parseDisclosureReport(ipoEventId, rceptNo);
+                reparsed.add(rceptNo);
+            } catch (Exception e) {
+                failed.add(rceptNo + ": " + e.getMessage());
+            }
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("ipoEventId", ipoEventId);
+        result.put("totalReports", rceptNos.size());
+        result.put("reparsed", reparsed);
+        result.put("failed", failed);
+
+        return ResponseEntity.ok(result);
+    }
+
+    // 재파싱이 필요한 모든 IPO의 공시를 일괄 재파싱하는 테스트 API
+    // 조건: status가 LISTED가 아니거나, listingDate가 추정값이거나, listingDate가 NULL
+    //       (= 잘못된 stale 추정값 때문에 LISTED로 잘못 마킹된 IPO도 자동 포함되어 복구됨)
+    // (구 엔드포인트명 reparse-all-upcoming → reparse-all-active 로 변경; UPCOMING만 잡으면 catch-22 발생)
+    @PostMapping("/reparse-all-active")
+    public ResponseEntity<Map<String, Object>> reparseAllActive() {
+        List<Object[]> activeProjections =
+                ipoEventRepository.findIdAndCompanyNameForActiveIpos(IpoEventStatus.LISTED);
+
+        List<Map<String, Object>> perIpoResult = new ArrayList<>();
+        int totalReparsed = 0;
+        int totalFailed = 0;
+
+        for (Object[] projection : activeProjections) {
+            Long ipoEventId = (Long) projection[0];
+            String companyName = (String) projection[1];
+
+            List<String> rceptNos = disclosureReportRepository.findRceptNosByIpoEventId(ipoEventId);
+
+            List<String> reparsed = new ArrayList<>();
+            List<String> failed = new ArrayList<>();
+
+            for (String rceptNo : rceptNos) {
+                try {
+                    dartDisclosureParsingService.parseDisclosureReport(ipoEventId, rceptNo);
+                    reparsed.add(rceptNo);
+                } catch (Exception e) {
+                    failed.add(rceptNo + ": " + e.getMessage());
+                }
+            }
+
+            totalReparsed += reparsed.size();
+            totalFailed += failed.size();
+
+            Map<String, Object> ipoResult = new LinkedHashMap<>();
+            ipoResult.put("ipoEventId", ipoEventId);
+            ipoResult.put("companyName", companyName);
+            ipoResult.put("reparsedCount", reparsed.size());
+            ipoResult.put("failedCount", failed.size());
+            if (!failed.isEmpty()) {
+                ipoResult.put("failed", failed);
+            }
+            perIpoResult.add(ipoResult);
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("activeIpoCount", activeProjections.size());
+        result.put("totalReparsed", totalReparsed);
+        result.put("totalFailed", totalFailed);
+        result.put("perIpo", perIpoResult);
+
+        return ResponseEntity.ok(result);
     }
 
     // 원문의 앞부분 일부만 잘라서 미리보기로 반환하는 메서드

--- a/src/main/java/com/gong/modu/domain/dto/ipo/IpoEventSearchItemResponse.java
+++ b/src/main/java/com/gong/modu/domain/dto/ipo/IpoEventSearchItemResponse.java
@@ -1,0 +1,23 @@
+package com.gong.modu.domain.dto.ipo;
+
+import com.gong.modu.domain.enums.ipo.IpoEventStatus;
+import com.gong.modu.domain.enums.ipo.MarketType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+// IpoEvent 검색 결과 한 건을 표현하는 DTO
+// 청약이력 4.2 현재 청약 중 이력 등록 시 종목 선택용 목록에서 사용
+@Getter
+@Builder
+public class IpoEventSearchItemResponse {
+
+    private Long ipoEventId;
+    private String companyName;
+    private MarketType marketType;
+    private IpoEventStatus status;
+    private LocalDate subscriptionStartDate;
+    private LocalDate subscriptionEndDate;
+    private LocalDate listingDate;
+}

--- a/src/main/java/com/gong/modu/domain/dto/ipo/IpoHomeItemResponse.java
+++ b/src/main/java/com/gong/modu/domain/dto/ipo/IpoHomeItemResponse.java
@@ -2,6 +2,7 @@ package com.gong.modu.domain.dto.ipo;
 
 import com.gong.modu.domain.enums.ipo.IpoEventStatus;
 import com.gong.modu.domain.enums.ipo.SignalLevel;
+import com.gong.modu.domain.enums.ipo.SignalUnavailableReason;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -33,8 +34,17 @@ public class IpoHomeItemResponse {
     // 청약 종료일
     private LocalDate subscriptionEndDate;
 
-    // 상장일
+    // 상장일 (실제 또는 청약종료일 + 7일 추정값)
     private LocalDate listingDate;
+
+    // listingDate가 청약종료일 기준 추정값인지 여부 (true = 추정, false/null = 확정)
+    private Boolean listingDateEstimated;
+
+    // 락업해제일 (AI 직접 추출 또는 listingDate + 락업기간 계산값)
+    private LocalDate lockupExpiryDate;
+
+    // lockupExpiryDate가 계산 추정값인지 여부 (true = 추정, false/null = AI 직접 추출 확정)
+    private Boolean lockupExpiryDateEstimated;
 
     // 희망 공모가 하단 (청약 시작 전 표시용)
     private BigDecimal offerPriceMin;
@@ -53,4 +63,11 @@ public class IpoHomeItemResponse {
 
     // 신호등 산출에 사용한 위험 점수 (지표가 부족하면 null)
     private BigDecimal riskScore;
+
+    // signalLevel이 null일 때 사유 (SPAC / PRE_DEMAND_FORECAST / INCOMPLETE_DATA)
+    // signalLevel이 있으면 null
+    private SignalUnavailableReason signalUnavailableReason;
+
+    // 로그인 사용자의 관심 공모주 등록 여부 (비로그인 시 false)
+    private boolean favorited;
 }

--- a/src/main/java/com/gong/modu/domain/dto/pipeline/AiDisclosureParsingResult.java
+++ b/src/main/java/com/gong/modu/domain/dto/pipeline/AiDisclosureParsingResult.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -16,6 +17,12 @@ public class AiDisclosureParsingResult {
     // 수요예측 종료일
     private String demandForecastEnd;
 
+    // 청약 시작일
+    private String subscriptionStart;
+
+    // 청약 종료일
+    private String subscriptionEnd;
+
     // 환불일
     private String refundDate;
 
@@ -24,6 +31,9 @@ public class AiDisclosureParsingResult {
 
     // 보호예수 또는 의무보유 해제일
     private String lockupExpiryDate;
+
+    // 대표 락업 기간(개월). 해제일 날짜가 없고 기간만 명시된 경우 채워짐
+    private Integer lockupPeriodMonths;
 
     // 희망 공모가 하단
     private BigDecimal offerPriceMin;
@@ -48,6 +58,9 @@ public class AiDisclosureParsingResult {
 
     // 보호예수 또는 매각제한 비율
     private BigDecimal protectiveCustodyRatio;
+
+    // 주관사·인수증권사 목록
+    private List<String> brokerNames;
 
     // AI가 판단한 간단한 근거
     // DB 저장용이 아닌 테스트 응답에서 확인하기 위함

--- a/src/main/java/com/gong/modu/domain/dto/pipeline/IpoDisclosureParsingResult.java
+++ b/src/main/java/com/gong/modu/domain/dto/pipeline/IpoDisclosureParsingResult.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Builder
@@ -17,6 +18,12 @@ public class IpoDisclosureParsingResult {
     // 수요예측 종료일
     private LocalDate demandForecastEnd;
 
+    // 청약 시작일
+    private LocalDate subscriptionStart;
+
+    // 청약 종료일
+    private LocalDate subscriptionEnd;
+
     // 환불일
     private LocalDate refundDate;
 
@@ -25,6 +32,9 @@ public class IpoDisclosureParsingResult {
 
     // 락업해제일
     private LocalDate lockupExpiryDate;
+
+    // 대표 락업 기간(개월). 해제일이 null이고 listingDate가 있을 때 계산에 사용
+    private Integer lockupPeriodMonths;
 
     // 희망 공모가 하단
     private BigDecimal offerPriceMin;
@@ -49,4 +59,7 @@ public class IpoDisclosureParsingResult {
 
     // 보호예수 비율
     private BigDecimal protectiveCustodyRatio;
+
+    // 주관사·인수증권사 목록
+    private List<String> brokerNames;
 }

--- a/src/main/java/com/gong/modu/domain/dto/user/CompleteHistoryRequest.java
+++ b/src/main/java/com/gong/modu/domain/dto/user/CompleteHistoryRequest.java
@@ -1,0 +1,32 @@
+package com.gong.modu.domain.dto.user;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+// ONGOING 청약 이력을 COMPLETED 로 전환할 때 사용하는 매도 정보 입력 요청
+@Getter
+@Setter
+@NoArgsConstructor
+public class CompleteHistoryRequest {
+
+    // 매도 단가 (필수)
+    @NotNull
+    @PositiveOrZero
+    private BigDecimal sellPrice;
+
+    @PositiveOrZero
+    private BigDecimal fee;
+
+    @PositiveOrZero
+    private BigDecimal tax;
+
+    // 매도일 (필수)
+    @NotNull
+    private LocalDate sellDate;
+}

--- a/src/main/java/com/gong/modu/domain/dto/user/CompletedHistoryCreateRequest.java
+++ b/src/main/java/com/gong/modu/domain/dto/user/CompletedHistoryCreateRequest.java
@@ -1,0 +1,58 @@
+package com.gong.modu.domain.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+// 4.1 과거 투자 이력 입력 요청 (DB 종목 조회 없이 사용자 직접 입력)
+// 등록 시 record_status = COMPLETED 로 저장
+@Getter
+@Setter
+@NoArgsConstructor
+public class CompletedHistoryCreateRequest {
+
+    // 종목명 (필수, 직접 입력)
+    @NotBlank
+    @Size(max = 200)
+    private String inputStockName;
+
+    // 회사명 (선택, 직접 입력)
+    @Size(max = 200)
+    private String inputCompanyName;
+
+    // 증권사 (선택)
+    @Size(max = 100)
+    private String securityCompany;
+
+    // 청약 수량
+    @PositiveOrZero
+    private Long subscribedQuantity;
+
+    // 배정 수량
+    @PositiveOrZero
+    private Long allocatedQuantity;
+
+    // 매도가
+    @PositiveOrZero
+    private BigDecimal sellPrice;
+
+    // 수수료
+    @PositiveOrZero
+    private BigDecimal fee;
+
+    // 제세금
+    @PositiveOrZero
+    private BigDecimal tax;
+
+    // 매도일
+    private LocalDate sellDate;
+
+    // 기타 비고
+    private String memo;
+}

--- a/src/main/java/com/gong/modu/domain/dto/user/InterestIpoItemResponse.java
+++ b/src/main/java/com/gong/modu/domain/dto/user/InterestIpoItemResponse.java
@@ -1,0 +1,33 @@
+package com.gong.modu.domain.dto.user;
+
+import com.gong.modu.domain.enums.ipo.IpoEventStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+// 관심 공모주 목록 응답 한 건을 표현하는 DTO
+// 홈 화면 리스트와 유사하게 디데이/공모가/증권사 정보를 함께 제공
+@Getter
+@Builder
+public class InterestIpoItemResponse {
+
+    private Long interestId;
+    private Long ipoEventId;
+    private String companyName;
+    private IpoEventStatus status;
+    private LocalDate subscriptionStartDate;
+    private LocalDate subscriptionEndDate;
+    private LocalDate listingDate;
+    private Boolean listingDateEstimated;
+    private LocalDate lockupExpiryDate;
+    private Boolean lockupExpiryDateEstimated;
+    private BigDecimal offerPriceMin;
+    private BigDecimal offerPriceMax;
+    private BigDecimal offerPrice;
+    private List<String> brokerNames;
+    private LocalDateTime interestedAt;
+}

--- a/src/main/java/com/gong/modu/domain/dto/user/OngoingHistoryCreateRequest.java
+++ b/src/main/java/com/gong/modu/domain/dto/user/OngoingHistoryCreateRequest.java
@@ -1,0 +1,41 @@
+package com.gong.modu.domain.dto.user;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+// 4.2 현재 청약 중 이력 입력 요청 (DB의 IpoEvent와 연결 필수)
+// 등록 시 record_status = ONGOING 으로 저장
+@Getter
+@Setter
+@NoArgsConstructor
+public class OngoingHistoryCreateRequest {
+
+    // 청약한 공모주 IpoEvent ID (필수, DB에 존재해야 함)
+    @NotNull
+    private Long ipoEventId;
+
+    // 청약 증권사
+    @Size(max = 100)
+    private String securityCompany;
+
+    // 청약 수량
+    @PositiveOrZero
+    private Long subscribedQuantity;
+
+    // 청약 시 공모가
+    @PositiveOrZero
+    private BigDecimal offerPrice;
+
+    // 청약에 투입한 금액
+    @PositiveOrZero
+    private BigDecimal subscriptionAmount;
+
+    // 메모
+    private String memo;
+}

--- a/src/main/java/com/gong/modu/domain/dto/user/SubscriptionHistoryResponse.java
+++ b/src/main/java/com/gong/modu/domain/dto/user/SubscriptionHistoryResponse.java
@@ -1,0 +1,65 @@
+package com.gong.modu.domain.dto.user;
+
+import com.gong.modu.domain.entity.user.UserSubscriptionHistory;
+import com.gong.modu.domain.enums.ipo.SubscriptionRecordStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+// 청약 이력 단건 응답 DTO
+@Getter
+@Builder
+public class SubscriptionHistoryResponse {
+
+    private Long id;
+    private SubscriptionRecordStatus recordStatus;
+
+    // 연결된 IpoEvent 정보 (없으면 null)
+    private Long ipoEventId;
+    private String ipoEventCompanyName;
+
+    // 사용자 직접 입력 종목명·회사명
+    private String inputStockName;
+    private String inputCompanyName;
+
+    private String securityCompany;
+    private Long subscribedQuantity;
+    private Long allocatedQuantity;
+    private BigDecimal offerPrice;
+    private BigDecimal subscriptionAmount;
+    private BigDecimal sellPrice;
+    private BigDecimal fee;
+    private BigDecimal tax;
+    private LocalDate sellDate;
+    private String memo;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static SubscriptionHistoryResponse from(UserSubscriptionHistory history) {
+        return SubscriptionHistoryResponse.builder()
+                .id(history.getId())
+                .recordStatus(history.getRecordStatus())
+                .ipoEventId(history.getIpoEvent() == null ? null : history.getIpoEvent().getId())
+                .ipoEventCompanyName(history.getIpoEvent() == null
+                        ? null
+                        : history.getIpoEvent().getCompany().getCorpName())
+                .inputStockName(history.getInputStockName())
+                .inputCompanyName(history.getInputCompanyName())
+                .securityCompany(history.getSecurityCompany())
+                .subscribedQuantity(history.getSubscribedQuantity())
+                .allocatedQuantity(history.getAllocatedQuantity())
+                .offerPrice(history.getOfferPrice())
+                .subscriptionAmount(history.getSubscriptionAmount())
+                .sellPrice(history.getSellPrice())
+                .fee(history.getFee())
+                .tax(history.getTax())
+                .sellDate(history.getSellDate())
+                .memo(history.getMemo())
+                .createdAt(history.getCreatedAt())
+                .updatedAt(history.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/gong/modu/domain/dto/user/SubscriptionHistoryUpdateRequest.java
+++ b/src/main/java/com/gong/modu/domain/dto/user/SubscriptionHistoryUpdateRequest.java
@@ -1,0 +1,51 @@
+package com.gong.modu.domain.dto.user;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+// 청약 이력 수정 요청 (모든 필드 선택, null이 아닌 값만 갱신)
+@Getter
+@Setter
+@NoArgsConstructor
+public class SubscriptionHistoryUpdateRequest {
+
+    @Size(max = 200)
+    private String inputStockName;
+
+    @Size(max = 200)
+    private String inputCompanyName;
+
+    @Size(max = 100)
+    private String securityCompany;
+
+    @PositiveOrZero
+    private Long subscribedQuantity;
+
+    @PositiveOrZero
+    private Long allocatedQuantity;
+
+    @PositiveOrZero
+    private BigDecimal offerPrice;
+
+    @PositiveOrZero
+    private BigDecimal subscriptionAmount;
+
+    @PositiveOrZero
+    private BigDecimal sellPrice;
+
+    @PositiveOrZero
+    private BigDecimal fee;
+
+    @PositiveOrZero
+    private BigDecimal tax;
+
+    private LocalDate sellDate;
+
+    private String memo;
+}

--- a/src/main/java/com/gong/modu/domain/entity/ipo/IpoEvent.java
+++ b/src/main/java/com/gong/modu/domain/entity/ipo/IpoEvent.java
@@ -66,6 +66,14 @@ public class IpoEvent extends BaseTimeEntity {
     @Column(name = "lockup_expiry_date")
     private LocalDate lockupExpiryDate; // 락업해제일
 
+    // 상장일이 거래소 승인 전이라 청약종료일 기준으로 추정해 채운 값인지 여부 (true = 추정값, false 또는 null = 확정값)
+    @Column(name = "listing_date_estimated")
+    private Boolean listingDateEstimated;
+
+    // 락업해제일이 listingDate + lockupPeriodMonths 로 계산된 값인지 여부 (true = 추정값, false 또는 null = AI 직접 추출 확정값)
+    @Column(name = "lockup_expiry_date_estimated")
+    private Boolean lockupExpiryDateEstimated;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "market_type", length = 20) // 시장 구분: KOSPI, KOSDAQ, KONEX
     private MarketType marketType; // 이 공모 이벤트가 목표로 하는 상장 시장
@@ -121,21 +129,54 @@ public class IpoEvent extends BaseTimeEntity {
         this.lockupExpiryDate = lockupExpiryDate;
     }
 
-    // DART 주요정보 API에서 확실하게 제공되는 일정만 갱신하는 메서드
+    // DART 주요정보 API에서 얻은 일정을 선택적으로 갱신하는 메서드
+    // estkRs는 항목별로 빈 값을 줄 수 있으므로, 값이 있을 때만 갱신해 기존 값을 보존한다
     public void updateDartSchedule(
             LocalDate subscriptionStartDate,
             LocalDate subscriptionEndDate,
             LocalDate paymentDate,
             LocalDate allocationDate
     ) {
-        this.subscriptionStartDate = subscriptionStartDate;
-        this.subscriptionEndDate = subscriptionEndDate;
-        this.paymentDate = paymentDate;
-        this.allocationDate = allocationDate;
+        if (subscriptionStartDate != null) {
+            this.subscriptionStartDate = subscriptionStartDate;
+        }
+        if (subscriptionEndDate != null) {
+            this.subscriptionEndDate = subscriptionEndDate;
+        }
+        if (paymentDate != null) {
+            this.paymentDate = paymentDate;
+        }
+        if (allocationDate != null) {
+            this.allocationDate = allocationDate;
+        }
     }
 
     public void updateStatus(IpoEventStatus status) { // 공모이벤트 진행 상태 변경 메서드
         this.status = status; // UPCOMING, ONGOING, CLOSED, LISTED 중 하나로 갱신
+    }
+
+    // 청약/상장 일정과 기준일을 비교해 현재 진행 상태를 계산하는 메서드
+    // status 컬럼은 시간이 지나면 낡으므로, 조회 시점 기준으로 상태를 다시 계산할 때 사용
+    public IpoEventStatus resolveStatus(LocalDate today) {
+        // 상장일이 있고 오늘 또는 과거라면 이미 상장된 상태
+        if (listingDate != null && !listingDate.isAfter(today)) {
+            return IpoEventStatus.LISTED;
+        }
+
+        // 오늘이 청약 시작일과 종료일 사이면 청약 진행중
+        if (subscriptionStartDate != null && subscriptionEndDate != null
+                && !today.isBefore(subscriptionStartDate)
+                && !today.isAfter(subscriptionEndDate)) {
+            return IpoEventStatus.ONGOING;
+        }
+
+        // 청약 종료일이 지났으면 청약 마감 (상장 전)
+        if (subscriptionEndDate != null && today.isAfter(subscriptionEndDate)) {
+            return IpoEventStatus.CLOSED;
+        }
+
+        // 위 조건에 모두 해당하지 않으면 청약 예정 상태
+        return IpoEventStatus.UPCOMING;
     }
 
     // 공모 이벤트 기본 정보 갱신 메서드
@@ -157,6 +198,8 @@ public class IpoEvent extends BaseTimeEntity {
     public void updateParsedSchedule(
             LocalDate demandForecastStart,
             LocalDate demandForecastEnd,
+            LocalDate subscriptionStartDate,
+            LocalDate subscriptionEndDate,
             LocalDate refundDate,
             LocalDate listingDate,
             LocalDate lockupExpiryDate
@@ -172,6 +215,16 @@ public class IpoEvent extends BaseTimeEntity {
             this.demandForecastEnd = demandForecastEnd;
         }
 
+        // 파싱된 청약 시작일이 있을 때만 기존 값을 갱신
+        if (subscriptionStartDate != null) {
+            this.subscriptionStartDate = subscriptionStartDate;
+        }
+
+        // 파싱된 청약 종료일이 있을 때만 기존 값을 갱신
+        if (subscriptionEndDate != null) {
+            this.subscriptionEndDate = subscriptionEndDate;
+        }
+
         // 파싱된 환불일이 있을 때만 기존 값을 갱신
         if (refundDate != null) {
             this.refundDate = refundDate;
@@ -185,6 +238,20 @@ public class IpoEvent extends BaseTimeEntity {
         // 파싱된 보호예수 해제일이 있을 때만 기존 값을 갱신
         if (lockupExpiryDate != null) {
             this.lockupExpiryDate = lockupExpiryDate;
+        }
+    }
+
+    // 상장일 추정 여부 갱신 메서드 (null이 아닌 경우에만 변경)
+    public void markListingDateEstimated(Boolean estimated) {
+        if (estimated != null) {
+            this.listingDateEstimated = estimated;
+        }
+    }
+
+    // 락업해제일 추정 여부 갱신 메서드 (null이 아닌 경우에만 변경)
+    public void markLockupExpiryDateEstimated(Boolean estimated) {
+        if (estimated != null) {
+            this.lockupExpiryDateEstimated = estimated;
         }
     }
 }

--- a/src/main/java/com/gong/modu/domain/entity/user/UserSubscriptionHistory.java
+++ b/src/main/java/com/gong/modu/domain/entity/user/UserSubscriptionHistory.java
@@ -154,4 +154,33 @@ public class UserSubscriptionHistory extends BaseTimeEntity {
     public void markOngoing() {
         this.recordStatus = SubscriptionRecordStatus.ONGOING;
     }
+
+    // 사용자가 임의 필드를 편집할 때 사용하는 메서드 (null은 기존 값 유지)
+    public void updateUserEditableFields(
+            String inputStockName,
+            String inputCompanyName,
+            String securityCompany,
+            Long subscribedQuantity,
+            Long allocatedQuantity,
+            BigDecimal offerPrice,
+            BigDecimal subscriptionAmount,
+            BigDecimal sellPrice,
+            BigDecimal fee,
+            BigDecimal tax,
+            LocalDate sellDate,
+            String memo
+    ) {
+        if (inputStockName != null) this.inputStockName = inputStockName;
+        if (inputCompanyName != null) this.inputCompanyName = inputCompanyName;
+        if (securityCompany != null) this.securityCompany = securityCompany;
+        if (subscribedQuantity != null) this.subscribedQuantity = subscribedQuantity;
+        if (allocatedQuantity != null) this.allocatedQuantity = allocatedQuantity;
+        if (offerPrice != null) this.offerPrice = offerPrice;
+        if (subscriptionAmount != null) this.subscriptionAmount = subscriptionAmount;
+        if (sellPrice != null) this.sellPrice = sellPrice;
+        if (fee != null) this.fee = fee;
+        if (tax != null) this.tax = tax;
+        if (sellDate != null) this.sellDate = sellDate;
+        if (memo != null) this.memo = memo;
+    }
 }

--- a/src/main/java/com/gong/modu/domain/enums/ipo/SignalUnavailableReason.java
+++ b/src/main/java/com/gong/modu/domain/enums/ipo/SignalUnavailableReason.java
@@ -1,0 +1,15 @@
+package com.gong.modu.domain.enums.ipo;
+
+// signalLevel이 null로 내려가는 사유를 표현하는 Enum
+// 프론트가 "수요예측 후 확정", "스팩 공모" 같은 안내를 분기 처리할 때 사용
+public enum SignalUnavailableReason {
+
+    // 스팩(기업인수목적회사)이라 수요예측 자체가 없음 → 신호등 산출 대상 아님
+    SPAC,
+
+    // 수요예측 전이라 지표가 아직 산출되지 않음 → 수요예측 후 자동 채워짐
+    PRE_DEMAND_FORECAST,
+
+    // 수요예측은 끝났지만 AI 파싱에서 지표를 못 뽑은 드문 케이스 → 재파싱 필요
+    INCOMPLETE_DATA
+}

--- a/src/main/java/com/gong/modu/exception/ErrorCode.java
+++ b/src/main/java/com/gong/modu/exception/ErrorCode.java
@@ -65,7 +65,16 @@ public enum ErrorCode {
     DISCLOSURE_PARSING_FAILED(HttpStatus.BAD_GATEWAY, "공시 원문 파싱 중 오류가 발생했습니다."),
 
     // AI를 이용한 공시 원문 보완 파싱이 실패한 경우 (Claude 응답은 왔지만 JSON 파싱 실패, 필드 변환 실패 등이 발생한 경우)
-    AI_DISCLOSURE_PARSING_FAILED(HttpStatus.BAD_GATEWAY, "AI 공시 보완 파싱 중 오류가 발생했습니다.");
+    AI_DISCLOSURE_PARSING_FAILED(HttpStatus.BAD_GATEWAY, "AI 공시 보완 파싱 중 오류가 발생했습니다."),
+
+    // 관심 공모주
+    ALREADY_INTERESTED_IPO(HttpStatus.CONFLICT, "이미 관심 공모주로 등록된 종목입니다."),
+    INTERESTED_IPO_NOT_FOUND(HttpStatus.NOT_FOUND, "관심 공모주 등록 내역을 찾을 수 없습니다."),
+
+    // 청약 이력
+    SUBSCRIPTION_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "청약 이력을 찾을 수 없습니다."),
+    SUBSCRIPTION_HISTORY_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 청약 이력만 조회/수정/삭제할 수 있습니다."),
+    SUBSCRIPTION_HISTORY_INVALID_INPUT(HttpStatus.BAD_REQUEST, "청약 이력 입력 값이 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/gong/modu/repository/ipo/IpoDisclosureReportRepository.java
+++ b/src/main/java/com/gong/modu/repository/ipo/IpoDisclosureReportRepository.java
@@ -1,8 +1,11 @@
 package com.gong.modu.repository.ipo;
 
 import com.gong.modu.domain.entity.ipo.IpoDisclosureReport;
+import com.gong.modu.domain.enums.ipo.IpoEventStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,4 +28,24 @@ public interface IpoDisclosureReportRepository extends JpaRepository<IpoDisclosu
     // original_text가 아직 없는 공시를 일부만 조회
     List<IpoDisclosureReport> findByOriginalTextIsNull(Pageable pageable);
 
+    // 특정 공모 이벤트의 공시 접수번호만 조회 (LOB 칼럼 미적재)
+    // PostgreSQL OID 기반 @Lob 칼럼은 트랜잭션 없이 읽으면 예외가 발생하므로,
+    // 컨트롤러처럼 트랜잭션 컨텍스트가 없는 곳에서는 이 projection 메서드를 사용
+    @Query("SELECT r.rceptNo FROM IpoDisclosureReport r WHERE r.ipoEvent.id = :ipoEventId")
+    List<String> findRceptNosByIpoEventId(@Param("ipoEventId") Long ipoEventId);
+
+    // 특정 상태(예: UPCOMING)의 IPO에 속한 모든 공시의 (ipoEventId, rceptNo) projection 조회
+    // 일괄 재파싱 스케줄러용. LOB 미적재 + lazy 연관 안 건드림
+    @Query("SELECT r.ipoEvent.id, r.rceptNo FROM IpoDisclosureReport r WHERE r.ipoEvent.status = :status")
+    List<Object[]> findIpoEventIdAndRceptNoByIpoStatus(@Param("status") IpoEventStatus status);
+
+    // 재파싱이 필요한 모든 IPO의 공시 (ipoEventId, rceptNo) projection 조회
+    // 조건: status가 LISTED가 아니거나, listingDate가 추정값이거나, listingDate가 NULL
+    //       (= 진짜 완료된 IPO만 제외하고 데이터 갱신이 의미 있는 모든 IPO를 포함)
+    // 잘못 LISTED로 마킹된 IPO(stale 추정값 때문)도 catch-22에서 빠져나올 수 있도록 함
+    @Query("SELECT r.ipoEvent.id, r.rceptNo FROM IpoDisclosureReport r " +
+            "WHERE r.ipoEvent.status != :listedStatus " +
+            "   OR r.ipoEvent.listingDateEstimated = true " +
+            "   OR r.ipoEvent.listingDate IS NULL")
+    List<Object[]> findReportsForActiveIpos(@Param("listedStatus") IpoEventStatus listedStatus);
 }

--- a/src/main/java/com/gong/modu/repository/ipo/IpoEventRepository.java
+++ b/src/main/java/com/gong/modu/repository/ipo/IpoEventRepository.java
@@ -5,6 +5,8 @@ import com.gong.modu.domain.enums.ipo.IpoEventStatus;
 import com.gong.modu.domain.enums.ipo.IpoEventType;
 import com.gong.modu.domain.enums.ipo.MarketType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -61,4 +63,26 @@ public interface IpoEventRepository extends JpaRepository<IpoEvent, Long> {
 
     // 상장일 기준 최신순 조회
     List<IpoEvent> findAllByOrderByListingDateDesc();
+
+    // 회사명 키워드 부분 일치 검색 (대소문자 구분 없음)
+    // 청약이력 4.2 현재 청약 중 이력 등록 시 IpoEvent 선택용
+    List<IpoEvent> findTop20ByCompany_CorpNameContainingIgnoreCaseOrderByCreatedAtDesc(String keyword);
+
+    // 특정 상태의 IpoEvent ID + 회사명을 projection으로 조회 (LazyInit 방지용)
+    // 트랜잭션 없는 컨트롤러나 스케줄러에서 lazy 로딩 없이 일괄 처리할 때 사용
+    @Query("SELECT e.id, e.company.corpName FROM IpoEvent e WHERE e.status = :status")
+    List<Object[]> findIdAndCompanyNameByStatus(@Param("status") IpoEventStatus status);
+
+    // 재파싱 대상 IpoEvent의 (id, companyName) projection 조회
+    // 조건: status가 LISTED가 아니거나, listingDate가 추정값이거나, listingDate가 NULL
+    @Query("SELECT e.id, e.company.corpName FROM IpoEvent e " +
+            "WHERE e.status != :listedStatus " +
+            "   OR e.listingDateEstimated = true " +
+            "   OR e.listingDate IS NULL")
+    List<Object[]> findIdAndCompanyNameForActiveIpos(@Param("listedStatus") IpoEventStatus listedStatus);
+
+    // 모든 IpoEvent의 status를 새로 계산하기 위한 일정 정보만 추출
+    // (id, subscriptionStartDate, subscriptionEndDate, listingDate, 현재 status)
+    @Query("SELECT e.id, e.subscriptionStartDate, e.subscriptionEndDate, e.listingDate, e.status FROM IpoEvent e")
+    List<Object[]> findAllScheduleSummaries();
 }

--- a/src/main/java/com/gong/modu/scheduler/ExternalDataScheduler.java
+++ b/src/main/java/com/gong/modu/scheduler/ExternalDataScheduler.java
@@ -67,17 +67,49 @@ public class ExternalDataScheduler {
         log.info("[Scheduler] DART IPO 데이터 동기화 종료");
     }
 
+    // 모든 IpoEvent의 status를 오늘 날짜 기준으로 다시 계산해 DB에 반영하는 스케줄러 메서드
+    // 매일 자정 30분에 실행되어 시간 경과로 인한 UPCOMING → ONGOING → CLOSED → LISTED 전이를 DB에 반영
+    // 응답은 resolveStatus(today)로 항상 최신이지만, status 컬럼 필터 쿼리(findByStatus 등)가
+    // stale 결과를 안 내도록 일일 동기화가 필요함
+    @Scheduled(cron = "0 30 0 * * *")
+    public void refreshIpoStatuses() {
+        log.info("[Scheduler] IPO 상태 자동 갱신 시작");
+        try {
+            int updated = dartIpoSyncService.refreshAllIpoStatuses();
+            log.info("[Scheduler] IPO 상태 자동 갱신 완료: {} 건 변경", updated);
+        } catch (Exception e) {
+            log.error("[Scheduler] IPO 상태 자동 갱신 실패", e);
+        }
+    }
+
     // 아직 원문이 파싱되지 않은 DART 공시를 찾아 ZIP 다운로드/파싱을 수행하는 스케줄러 메서드
-    @Scheduled(cron = "0 0 2 * * *")
+    // 새벽 2시(DART 동기화 완료 후) + 오전 8시(당일 업무 전 보완 처리) 하루 2회 실행
+    @Scheduled(cron = "0 0 2,8 * * *")
     public void parseUnparsedDartDisclosureDocuments() {
         log.info("[Scheduler] DART 공시 원문 ZIP 파싱 시작");
         try {
-            dartDisclosureParsingService.parseUnparsedDisclosureReports(20);
+            dartDisclosureParsingService.parseUnparsedDisclosureReports(50);
         } catch (Exception e) {
             log.error("[Scheduler] DART 공시 원문 ZIP 파싱 실패", e);
         }
 
         log.info("[Scheduler] DART 공시 원문 ZIP 파싱 종료");
+    }
+
+    // 활성 IPO(LISTED + 확정 listingDate가 아닌 모든 IPO)의 공시를 매일 일괄 재파싱
+    // 컨텍스트 추출 로직이나 AI 프롬프트가 개선되면 신규 공시가 적은 환경에서도
+    // 기존 데이터에 자동으로 적용되도록 함 (개발자 수동 호출 불필요)
+    // 잘못된 stale 추정값 때문에 LISTED로 잘못 마킹된 IPO도 자동 복구 가능
+    // 새벽 3시 (parse-unparsed 2시 완료 후) 실행
+    @Scheduled(cron = "0 0 3 * * *")
+    public void reparseActiveIpos() {
+        log.info("[Scheduler] 활성 IPO 일괄 재파싱 시작");
+        try {
+            dartDisclosureParsingService.reparseAllActiveIpos();
+        } catch (Exception e) {
+            log.error("[Scheduler] 활성 IPO 일괄 재파싱 실패", e);
+        }
+        log.info("[Scheduler] 활성 IPO 일괄 재파싱 종료");
     }
 
 

--- a/src/main/java/com/gong/modu/service/ipo/IpoHomeQueryService.java
+++ b/src/main/java/com/gong/modu/service/ipo/IpoHomeQueryService.java
@@ -1,12 +1,16 @@
 package com.gong.modu.service.ipo;
 
+import com.gong.modu.domain.dto.ipo.IpoEventSearchItemResponse;
 import com.gong.modu.domain.dto.ipo.IpoHomeItemResponse;
 import com.gong.modu.domain.entity.ipo.IpoEvent;
 import com.gong.modu.domain.entity.ipo.IpoEventBroker;
 import com.gong.modu.domain.entity.ipo.IpoOffering;
 import com.gong.modu.domain.enums.ipo.IpoScheduleFilter;
+import com.gong.modu.domain.enums.ipo.SignalLevel;
+import com.gong.modu.domain.enums.ipo.SignalUnavailableReason;
 import com.gong.modu.repository.ipo.IpoEventBrokerRepository;
 import com.gong.modu.repository.ipo.IpoEventRepository;
+import com.gong.modu.service.user.InterestIpoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +19,7 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 // 홈 화면 청약 일정 리스트업을 담당하는 조회 서비스
 // 기능명세서 3.1.1 청약 일정 리스트업 참고
@@ -29,20 +34,50 @@ public class IpoHomeQueryService {
     private final IpoEventRepository ipoEventRepository;
     private final IpoEventBrokerRepository ipoEventBrokerRepository;
     private final IpoSignalCalculator ipoSignalCalculator;
+    private final InterestIpoService interestIpoService;
 
     // 홈 화면용 청약 일정 리스트를 필터 기준으로 조회하는 메서드
     // 필터에 해당하는 일정일이 최근 3개월~향후 4주 범위에 드는 공모주를 일정일 순으로 반환
+    // userId가 있으면 각 항목의 favorited 필드를 채워 반환
     @Transactional(readOnly = true)
-    public List<IpoHomeItemResponse> getHomeSchedule(IpoScheduleFilter filter) {
+    public List<IpoHomeItemResponse> getHomeSchedule(IpoScheduleFilter filter, Long userId) {
         LocalDate today = LocalDate.now();
         LocalDate from = today.minusMonths(PAST_MONTHS);
         LocalDate to = today.plusWeeks(FUTURE_WEEKS);
 
+        Set<Long> favoritedIds = interestIpoService.getInterestedIpoEventIds(userId);
+
         return findEventsByFilter(filter, from, to).stream()
                 .filter(event -> filterDate(event, filter) != null)
                 .sorted(Comparator.comparing((IpoEvent event) -> filterDate(event, filter)))
-                .map(event -> toHomeItem(event, today, filter))
+                .map(event -> toHomeItem(event, today, filter, favoritedIds.contains(event.getId())))
                 .toList();
+    }
+
+    // 회사명 키워드로 IpoEvent를 검색하는 메서드 (청약이력 4.2 종목 선택용)
+    @Transactional(readOnly = true)
+    public List<IpoEventSearchItemResponse> searchIpoEvents(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return List.of();
+        }
+
+        return ipoEventRepository
+                .findTop20ByCompany_CorpNameContainingIgnoreCaseOrderByCreatedAtDesc(keyword.trim())
+                .stream()
+                .map(this::toSearchItem)
+                .toList();
+    }
+
+    private IpoEventSearchItemResponse toSearchItem(IpoEvent event) {
+        return IpoEventSearchItemResponse.builder()
+                .ipoEventId(event.getId())
+                .companyName(event.getCompany().getCorpName())
+                .marketType(event.getMarketType())
+                .status(event.resolveStatus(LocalDate.now()))
+                .subscriptionStartDate(event.getSubscriptionStartDate())
+                .subscriptionEndDate(event.getSubscriptionEndDate())
+                .listingDate(event.getListingDate())
+                .build();
     }
 
     // 필터 종류에 따라 해당 일정일 기준으로 공모 이벤트를 조회하는 메서드
@@ -70,7 +105,7 @@ public class IpoHomeQueryService {
     }
 
     // 공모 이벤트 한 건을 홈 리스트 응답 DTO로 변환하는 메서드
-    private IpoHomeItemResponse toHomeItem(IpoEvent event, LocalDate today, IpoScheduleFilter filter) {
+    private IpoHomeItemResponse toHomeItem(IpoEvent event, LocalDate today, IpoScheduleFilter filter, boolean favorited) {
         IpoOffering offering = event.getOffering();
         IpoSignalCalculator.SignalResult signal = ipoSignalCalculator.calculate(event.getMetric());
 
@@ -83,18 +118,45 @@ public class IpoHomeQueryService {
         return IpoHomeItemResponse.builder()
                 .ipoEventId(event.getId())
                 .companyName(event.getCompany().getCorpName())
-                .status(event.getStatus())
+                .status(event.resolveStatus(today))
                 .dDayLabel(buildDDayLabel(event, today, filter))
                 .subscriptionStartDate(event.getSubscriptionStartDate())
                 .subscriptionEndDate(event.getSubscriptionEndDate())
                 .listingDate(event.getListingDate())
+                .listingDateEstimated(event.getListingDateEstimated())
+                .lockupExpiryDate(event.getLockupExpiryDate())
+                .lockupExpiryDateEstimated(event.getLockupExpiryDateEstimated())
                 .offerPriceMin(offering == null ? null : offering.getOfferPriceMin())
                 .offerPriceMax(offering == null ? null : offering.getOfferPriceMax())
                 .offerPrice(offering == null ? null : offering.getOfferPrice())
                 .brokerNames(brokerNames)
                 .signalLevel(signal.signalLevel())
                 .riskScore(signal.riskScore())
+                .signalUnavailableReason(resolveSignalUnavailableReason(event, signal.signalLevel(), today))
+                .favorited(favorited)
                 .build();
+    }
+
+    // signalLevel이 null인 사유를 결정하는 메서드
+    // - 스팩 종목: SPAC
+    // - 수요예측 종료일이 미래거나 없음: PRE_DEMAND_FORECAST
+    // - 그 외(수요예측 후인데 지표 부족): INCOMPLETE_DATA
+    static SignalUnavailableReason resolveSignalUnavailableReason(IpoEvent event, SignalLevel signalLevel, LocalDate today) {
+        if (signalLevel != null) {
+            return null;
+        }
+
+        String corpName = event.getCompany().getCorpName();
+        if (corpName != null && (corpName.contains("기업인수목적") || corpName.contains("스팩"))) {
+            return SignalUnavailableReason.SPAC;
+        }
+
+        LocalDate demandEnd = event.getDemandForecastEnd();
+        if (demandEnd == null || !today.isAfter(demandEnd)) {
+            return SignalUnavailableReason.PRE_DEMAND_FORECAST;
+        }
+
+        return SignalUnavailableReason.INCOMPLETE_DATA;
     }
 
     // 필터 기준으로 디데이 라벨을 만드는 메서드

--- a/src/main/java/com/gong/modu/service/pipeline/AiDisclosureParsingService.java
+++ b/src/main/java/com/gong/modu/service/pipeline/AiDisclosureParsingService.java
@@ -7,11 +7,13 @@ import com.gong.modu.exception.CustomException;
 import com.gong.modu.exception.ErrorCode;
 import com.gong.modu.service.AnthropicService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 // Claude API로 공시 원문에서 정규식이 놓친 IPO 핵심값을 보완 추출하는 서비스 클래스
@@ -47,8 +49,17 @@ public class AiDisclosureParsingService {
             String json = extractJson(aiText);
 
             return objectMapper.readValue(json, AiDisclosureParsingResult.class);
+        } catch (CustomException e) {
+            // AnthropicService에서 던진 CustomException(크레딧 한도 등)은 원형 그대로 다시 던져
+            // 원본 에러 코드와 메시지가 응답에 노출되도록 함
+            log.warn("[AI Parser] CustomException from Anthropic: code={}, message={}",
+                    e.getErrorCode(), e.getMessage());
+            throw e;
         } catch (Exception e) {
-            // 클로드 응답이 JSON 형식이 아니거나 ObjectMapper 변환에 실패하면 AI 보완 파싱 실패로 처리
+            // Claude 응답 JSON 변환 실패 또는 기타 예외
+            // 원본 에러 클래스와 메시지를 로깅해 실제 원인(rate limit, network 등)을 추적 가능하게 함
+            log.warn("[AI Parser] AI 파싱 실패: exception={}, message={}",
+                    e.getClass().getSimpleName(), e.getMessage(), e);
             throw new CustomException(ErrorCode.AI_DISCLOSURE_PARSING_FAILED);
         }
     }
@@ -70,21 +81,26 @@ public class AiDisclosureParsingService {
                 8. 주식 수는 주 단위 숫자만 반환한다. 예: 65,450,000주는 65450000
                 9. 경쟁률은 '1732.83 대 1'이면 1732.83으로 반환한다.
                 10. 비율은 반드시 0~1 사이 소수로 반환한다. 예: 45.36%%는 0.4536
-                11. 보호예수/의무보유 해제일이 여러 개라 대표 단일 날짜를 확정하기 어려우면 null로 둔다.
+                11. lockupExpiryDate(보호예수·의무보유 해제일): 여러 대상의 해제일이 있을 경우, 최대주주·발행사 임원 등 대주주에 해당하는 해제일(통상 상장 후 6개월)을 대표값으로 사용한다. 명시된 날짜가 없어도 문맥에서 "상장 후 N개월" 형태로 기간을 확인할 수 있으면 lockupPeriodMonths에 그 개월 수를 숫자로 반환하고 lockupExpiryDate는 null로 둔다. 어떤 값도 확인 불가면 둘 다 null.
                 12. institutionalCompetitionRate(기관경쟁률): 수요예측 참여내역 표에서 합계 행의 경쟁률 값을 사용한다. 표에 '1,732.83'처럼 합계 경쟁률이 있으면 반드시 추출한다.
                 13. lockupRatio(의무보유확약 비율): 문맥에 확약비율이 명시되어 있으면 그 값을 사용하고, 명시되지 않은 경우 (확약 수량 합계) ÷ (수요예측 총 신청수량)으로 계산해서 반환한다.
                 14. demandForecastStart/demandForecastEnd(수요예측 기간): 일정표의 '수요예측 기간' 또는 '수요예측일' 행뿐만 아니라, 본문 산문에서도 추출한다. 예를 들어 '공동대표주관회사는 2021년 7월 13일부터 7월 14일까지 수요예측을 실시하였습니다', 'OOO일 양일간 수요예측을 진행' 같은 과거형 서술 문장에서 시작일과 종료일을 추출한다. 표가 없어도 산문에서 확인되면 채운다.
-                15. listingDate(상장예정일): 일정표의 '상장예정일' 또는 '매매개시일' 행뿐만 아니라, 본문 산문의 'OOO일 상장 예정', 'OOO일부터 매매가 개시될 예정' 같은 서술 문장에서도 추출한다.
-                16. reason 필드에는 주요 값을 어떤 근거로 추출/계산했는지 간단히 한 문장으로 기재한다.
+                15. listingDate(상장예정일): 가장 중요한 필드 중 하나이므로 반드시 적극적으로 찾아라. 문맥 맨 앞 [CRITICAL_KEYWORDS] 블록에서 '상장예정일', '매매개시일', '상장일' 키워드 주변을 먼저 확인한다. 일정표의 행, 본문 산문의 'OOO일 상장 예정', 'OOO일부터 매매가 개시될 예정', '상장일(매매개시일) YYYY년 MM월 DD일', '상장(예정)일: ...' 같은 어떤 형태로든 나타나면 추출한다. 정정 후 값 우선. 한국 거래소는 청약 종료 후 통상 5~7영업일 뒤 상장하므로 청약일이 정해진 공시라면 상장일도 함께 명시되어 있는 경우가 대부분이다. 진짜로 어디에도 없을 때만 null.
+                16. subscriptionStart/subscriptionEnd(청약 기간): 일정표의 '청약기일' 또는 '청약일' 행에서 일반투자자(일반청약자) 기준 청약 시작일과 종료일을 추출한다. 청약일이 하루뿐이면 시작일과 종료일을 같은 날짜로 둔다.
+                17. brokerNames(주관사·인수증권사): 대표주관회사, 공동대표주관회사, 인수회사 등 이 공모에 참여한 증권사명을 문자열 배열로 추출한다. 예: ["KB증권", "한국투자증권"]. '주식회사' 같은 수식어는 빼고 증권사명만 간결하게 넣고, 중복은 제거한다. 없으면 빈 배열이 아니라 null로 둔다.
+                18. reason 필드에는 주요 값을 어떤 근거로 추출/계산했는지 간단히 한 문장으로 기재한다.
 
                 반환 JSON 형식은 반드시 아래와 같아야 한다.
 
                 {
                   "demandForecastStart": null,
                   "demandForecastEnd": null,
+                  "subscriptionStart": null,
+                  "subscriptionEnd": null,
                   "refundDate": null,
                   "listingDate": null,
                   "lockupExpiryDate": null,
+                  "lockupPeriodMonths": null,
                   "offerPriceMin": null,
                   "offerPriceMax": null,
                   "offerPrice": null,
@@ -93,6 +109,7 @@ public class AiDisclosureParsingService {
                   "institutionalCompetitionRate": null,
                   "lockupRatio": null,
                   "protectiveCustodyRatio": null,
+                  "brokerNames": null,
                   "reason": null
                 }
 

--- a/src/main/java/com/gong/modu/service/pipeline/DartDisclosureParsingService.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DartDisclosureParsingService.java
@@ -1,219 +1,136 @@
 package com.gong.modu.service.pipeline;
 
-import com.gong.modu.client.DartApiClient;
-import com.gong.modu.domain.dto.pipeline.AiDisclosureParsingResult;
-import com.gong.modu.domain.dto.pipeline.IpoDisclosureParsingResult;
 import com.gong.modu.domain.entity.ipo.IpoDisclosureReport;
-import com.gong.modu.domain.entity.ipo.IpoEvent;
-import com.gong.modu.domain.entity.ipo.IpoMetric;
-import com.gong.modu.domain.entity.ipo.IpoOffering;
-import com.gong.modu.domain.enums.ipo.DisclosureDocumentType;
-import com.gong.modu.exception.CustomException;
-import com.gong.modu.exception.ErrorCode;
+import com.gong.modu.domain.enums.ipo.IpoEventStatus;
 import com.gong.modu.repository.ipo.IpoDisclosureReportRepository;
-import com.gong.modu.repository.ipo.IpoEventRepository;
-import com.gong.modu.repository.ipo.IpoMetricRepository;
-import com.gong.modu.repository.ipo.IpoOfferingRepository;
 import com.gong.modu.util.RedisUtil;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
-// DART 공시 원문 ZIP을 다운로드하고 AI 파싱을 수행한 뒤, 일부 IPO 핵심값을 파싱하여 DB에 반영하는 서비스 클래스
+// 미파싱 공시 목록을 조회하고 병렬로 파싱 작업을 분배하는 오케스트레이터
+// 실제 파싱 트랜잭션은 DisclosureParsingExecutor에 위임하여 @Transactional이 정상 동작하게 함
 public class DartDisclosureParsingService {
 
-    private final DartApiClient dartApiClient;
-    private final DisclosureTextExtractor disclosureTextExtractor;
-    private final IpoEventRepository ipoEventRepository;
-    private final IpoOfferingRepository ipoOfferingRepository;
-    private final IpoMetricRepository ipoMetricRepository;
     private final IpoDisclosureReportRepository disclosureReportRepository;
     private final RedisUtil redisUtil;
-    private final IpoDisclosureDocumentClassifier ipoDisclosureDocumentClassifier;
+    private final DisclosureParsingExecutor disclosureParsingExecutor;
+    private final Executor disclosureParsingPool;
 
-    // AI 파싱에 필요한 문맥을 추출하는 클래스
-    private final DisclosureContextExtractor disclosureContextExtractor;
-    // 클로드를 호출해서 IPO 핵심값을 추출하는 서비스
-    private final AiDisclosureParsingService aiDisclosureParsingService;
-    // AI 파싱 결과를 검증·변환하는 클래스
-    private final DisclosureParsingResultMerger disclosureParsingResultMerger;
+    public DartDisclosureParsingService(
+            IpoDisclosureReportRepository disclosureReportRepository,
+            RedisUtil redisUtil,
+            DisclosureParsingExecutor disclosureParsingExecutor,
+            @Qualifier("disclosureParsingPool") Executor disclosureParsingPool
+    ) {
+        this.disclosureReportRepository = disclosureReportRepository;
+        this.redisUtil = redisUtil;
+        this.disclosureParsingExecutor = disclosureParsingExecutor;
+        this.disclosureParsingPool = disclosureParsingPool;
+    }
 
-    // 아직 original_text가 없는 공시들을 일정 개수만큼 찾아 원문 ZIP 다운로드/파싱을 수행하는 메서드
+    // 아직 original_text가 없는 공시들을 일정 개수만큼 찾아 병렬로 파싱을 수행하는 메서드
+    // 같은 IPO의 공시는 순차 처리(race condition 방지), 다른 IPO끼리만 병렬
     public void parseUnparsedDisclosureReports(int limit) {
-        // 공시 조회
         List<IpoDisclosureReport> reports = disclosureReportRepository
                 .findByOriginalTextIsNull(PageRequest.of(0, limit));
 
         if (reports.isEmpty()) {
-            log.info("DART Disclosure Parsing] 미파싱 공시 없음");
+            log.info("[DART Disclosure Parsing] 미파싱 공시 없음");
             return;
         }
 
-        for (IpoDisclosureReport report : reports) {
-
-            String rceptNo = report.getRceptNo();
-
-            // 최근 실패한 공시는 일정 시간 동안 재시도 X
-            if (redisUtil.isDisclosureParsingRecentlyFailed(rceptNo)) {
-                log.info("[DART Disclosure Parsing] 최근 실패 이력으로 건너뜀: rceptNo={}", rceptNo);
-                continue;
-            }
-
-            // 같은 공시를 여러 스케줄러 인스턴스가 동시에 처리하지 않도록 Redis lock을 획득
-            boolean locked = redisUtil.tryLockDisclosureParsing(rceptNo, 30);
-
-            if (!locked) {
-                log.info("[DART Disclosure Parsing] 이미 파싱 중인 공시로 건너뜀: rceptNo={}", rceptNo);
-                continue;
-            }
-
-            try {
-                // 각 공시마다 단건 파싱 메서드 호출
-                parseDisclosureReport(report.getIpoEvent().getId(), rceptNo);
-            } catch (Exception e) {
-                // 실패한 공시는 6시간 동안 재시도를 막음
-                redisUtil.markDisclosureParsingFailed(rceptNo, 6);
-
-                log.warn("[DART Disclosure Parsing] 공시 원문 파싱 실패: rceptNo={}", rceptNo, e);
-            } finally {
-                // 성공/실패 여부와 관계없이 lock은 해제
-                redisUtil.unlockDisclosureParsing(rceptNo);
-            }
-        }
-
-    }
-
-    // DART 공시 접수번호를 기준으로 ZIP 다운로드, 텍스트 추출, 정규식 파싱, AI 보완 파싱, DB 반영까지 수행하는 메서드
-    @Transactional
-    public void parseDisclosureReport(Long ipoEventId, String rceptNo) {
-        IpoEvent ipoEvent = ipoEventRepository.findById(ipoEventId)
-                .orElseThrow(() -> new CustomException(ErrorCode.IPO_EVENT_NOT_FOUND));
-
-        // DART 공시 원문 ZIP 파일 다운로드
-        byte[] zipBytes = dartApiClient.downloadDisclosureDocumentZip(rceptNo);
-
-        // 텍스트 추출
-        String originalText = disclosureTextExtractor.extractTextFromZip(zipBytes);
-
-        if (originalText == null || originalText.isBlank()) {
-            throw new CustomException(ErrorCode.DISCLOSURE_PARSING_FAILED);
-        }
-
-        // 원문 텍스트 기준으로 문서 성격을 다시 판별
-        DisclosureDocumentType documentType =
-                ipoDisclosureDocumentClassifier.detectDocumentType(originalText);
-
-        // 원문 텍스트와 documentType을 ipo_disclosure_reports에 저장하거나 갱신
-        upsertDisclosureOriginalText(ipoEvent, rceptNo, originalText, documentType);
-
-        // IPO 관련 문서가 아니라면 파싱 X
-        if (documentType == DisclosureDocumentType.NON_IPO_DOCUMENT) {
-            log.info(
-                    "[DART Disclosure Parsing] IPO 관련 공시가 아니므로 값 파싱 건너뜀: rceptNo={}, documentType={}",
-                    rceptNo,
-                    documentType
-            );
-            return;
-        }
-
-        // 원문에서 AI 파싱에 필요한 섹션 문맥을 추출
-        String aiContext = disclosureContextExtractor.extractContext(originalText);
-
-        // AI 파싱 결과를 담을 변수
-        AiDisclosureParsingResult aiResult = null;
-
-        if (aiContext != null && !aiContext.isBlank()) {
-            aiResult = aiDisclosureParsingService.parseWithAi(aiContext);
-        }
-
-        // AI 결과를 검증·변환하여 최종 파싱 결과 생성
-        IpoDisclosureParsingResult parsingResult =
-                disclosureParsingResultMerger.toResult(aiResult);
-
-        // 파싱 결과를 ipo_events, ipo_offerings, ipo_metrics에 반영
-        applyParsingResult(ipoEvent, parsingResult);
-
-    }
-
-    // 공시 원문 텍스트를 ipo_disclosure_reports에에 저장하거나 갱신하는 메서드
-    private IpoDisclosureReport upsertDisclosureOriginalText(
-            IpoEvent ipoEvent,
-            String rceptNo,
-            String originalText,
-            DisclosureDocumentType documentType
-    ) {
-        return disclosureReportRepository.findByIpoEventIdAndRceptNo(ipoEvent.getId(), rceptNo)
-                .map(existing -> {
-                    // 기존 공시 레코드의 원문 텍스트를 최신 추출 결과로 갱신
-                    existing.updateOriginalText(originalText);
-
-                    // 원문 텍스트 기준으로 다시 판별한 문서 성격을 갱신
-                    existing.updateDocumentType(documentType);
-
-                    return existing;
+        // 실패 이력 / lock 필터링 후 IPO별로 그룹핑
+        Map<Long, List<IpoDisclosureReport>> grouped = reports.stream()
+                .filter(report -> {
+                    if (redisUtil.isDisclosureParsingRecentlyFailed(report.getRceptNo())) {
+                        log.info("[DART Disclosure Parsing] 최근 실패 이력으로 건너뜀: rceptNo={}", report.getRceptNo());
+                        return false;
+                    }
+                    return true;
                 })
-                .orElseGet(() -> disclosureReportRepository.save(
-                        IpoDisclosureReport.builder()
-                                .ipoEvent(ipoEvent)
-                                .rceptNo(rceptNo)
-                                .reportName("DART 원문 공시") // 임시명
-                                .documentType(documentType)
-                                .originalText(originalText)
-                                .build()
-                ));
+                .filter(report -> {
+                    if (!redisUtil.tryLockDisclosureParsing(report.getRceptNo(), 30)) {
+                        log.info("[DART Disclosure Parsing] 이미 파싱 중인 공시로 건너뜀: rceptNo={}", report.getRceptNo());
+                        return false;
+                    }
+                    return true;
+                })
+                .collect(Collectors.groupingBy(r -> r.getIpoEvent().getId()));
+
+        List<CompletableFuture<Void>> futures = grouped.values().stream()
+                .map(reportsInOneIpo -> CompletableFuture.runAsync(() -> {
+                    for (IpoDisclosureReport report : reportsInOneIpo) {
+                        String rceptNo = report.getRceptNo();
+                        try {
+                            disclosureParsingExecutor.parseDisclosureReport(
+                                    report.getIpoEvent().getId(), rceptNo);
+                        } catch (Exception e) {
+                            redisUtil.markDisclosureParsingFailed(rceptNo, 6);
+                            log.warn("[DART Disclosure Parsing] 공시 원문 파싱 실패: rceptNo={}", rceptNo, e);
+                        } finally {
+                            redisUtil.unlockDisclosureParsing(rceptNo);
+                        }
+                    }
+                }, disclosureParsingPool))
+                .toList();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
     }
 
-    // 파싱 결과를 각 엔티티에 반영하는 메서드
-    private void applyParsingResult(
-            IpoEvent ipoEvent,
-            IpoDisclosureParsingResult result
-    ) {
-        // 공시 원문에서 추출한 일정 정보를 ipo_events에 반영
-        ipoEvent.updateParsedSchedule(
-                result.getDemandForecastStart(),
-                result.getDemandForecastEnd(),
-                result.getRefundDate(),
-                result.getListingDate(),
-                result.getLockupExpiryDate()
-        );
+    // 테스트·수동 재파싱용 단건 호출 (DisclosureParserTestController 등에서 사용)
+    public void parseDisclosureReport(Long ipoEventId, String rceptNo) {
+        disclosureParsingExecutor.parseDisclosureReport(ipoEventId, rceptNo);
+    }
 
-        // 공모조건 조회
-        IpoOffering offering = ipoOfferingRepository.findByIpoEventId(ipoEvent.getId())
-                .orElseGet(() -> ipoOfferingRepository.save(
-                        IpoOffering.builder()
-                                .ipoEvent(ipoEvent)
-                                .build()
+    // 재파싱이 필요한 모든 IPO의 공시를 일괄 재파싱하는 메서드
+    // "재파싱이 필요한" 정의: status가 LISTED가 아니거나 listingDate가 추정값/NULL인 IPO
+    //   → 진짜 완료된 IPO는 skip, 활성 IPO + 의심스러운 LISTED는 모두 포함
+    // 잘못된 stale 추정값 때문에 LISTED로 잘못 마킹된 IPO도 다시 잡혀 정상 복원됨
+    // 같은 IPO의 공시는 순차 처리(race condition 방지), 다른 IPO끼리만 병렬
+    public void reparseAllActiveIpos() {
+        List<Object[]> reports = disclosureReportRepository
+                .findReportsForActiveIpos(IpoEventStatus.LISTED);
+
+        if (reports.isEmpty()) {
+            log.info("[DART Disclosure Parsing] 재파싱 대상 IPO 없음");
+            return;
+        }
+
+        // IPO별로 그룹핑 (Long → List<String>)
+        Map<Long, List<String>> reportsByIpo = reports.stream()
+                .collect(Collectors.groupingBy(
+                        row -> (Long) row[0],
+                        Collectors.mapping(row -> (String) row[1], Collectors.toList())
                 ));
 
-        // 파싱된 공모가, 공모주식수, 상장주식수를 공모 조건에 반영
-        offering.updateParsedOfferingInfo(
-                result.getShareCount(),
-                result.getTotalListedShares(),
-                result.getOfferPriceMin(),
-                result.getOfferPriceMax(),
-                result.getOfferPrice()
-        );
+        log.info("[DART Disclosure Parsing] 활성 IPO 재파싱 시작: {} IPO, {} 건",
+                reportsByIpo.size(), reports.size());
 
-        // 공모지표 조회
-        IpoMetric metric = ipoMetricRepository.findByIpoEventId(ipoEvent.getId())
-                .orElseGet(() -> ipoMetricRepository.save(
-                        IpoMetric.builder()
-                                .ipoEvent(ipoEvent)
-                                .build()
-                ));
+        List<CompletableFuture<Void>> futures = reportsByIpo.entrySet().stream()
+                .map(entry -> CompletableFuture.runAsync(() -> {
+                    Long ipoEventId = entry.getKey();
+                    for (String rceptNo : entry.getValue()) {
+                        try {
+                            disclosureParsingExecutor.parseDisclosureReport(ipoEventId, rceptNo);
+                        } catch (Exception e) {
+                            log.warn("[DART Disclosure Parsing] 재파싱 실패: rceptNo={}", rceptNo, e);
+                        }
+                    }
+                }, disclosureParsingPool))
+                .toList();
 
-        // 파싱된 기관경쟁률, 의무보유확약, 락업 비율을 지표에 반영
-        metric.updateParsedMetrics(
-                result.getInstitutionalCompetitionRate(),
-                result.getLockupRatio(),
-                result.getProtectiveCustodyRatio()
-        );
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        log.info("[DART Disclosure Parsing] 활성 IPO 재파싱 완료: {} 건", reports.size());
     }
 }

--- a/src/main/java/com/gong/modu/service/pipeline/DartIpoSyncService.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DartIpoSyncService.java
@@ -17,7 +17,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 @Service
@@ -29,8 +31,23 @@ public class DartIpoSyncService {
     // DART 공시 유형 코드 - C: 발행공시 (증권신고서, 투자설명서, 증권발행실적보고서 등)
     private static final String ISSUANCE_DISCLOSURE_TYPE = "C";
 
+    // DART 법인구분 코드 - E: 기타법인 (상장 전 기업 = 신규 IPO 후보)
+    // 유상증자·합병 공시를 내는 기존 상장사(Y/K/N)를 발견 단계에서 제외하기 위함
+    private static final String NON_LISTED_CORP_CLASS = "E";
+
     // 시장 전체 공시 검색 시 페이지네이션 안전 상한
     private static final int MAX_SEARCH_PAGES = 50;
+
+    // DART 시장 전체 공시검색은 조회 기간을 약 3개월로 제한하므로, 한 번에 검색할 최대 일수
+    private static final int MAX_SEARCH_RANGE_DAYS = 80;
+
+    // 기업별 동기화 시 과거로 거슬러 조회할 개월 수
+    // estkRs는 '최초접수일' 기준으로 필터링되는데, 한 IPO는 최초 증권신고서~상장까지 수개월이 걸리므로
+    // 발견 윈도우보다 더 과거까지 봐야 최초 증권신고서를 놓치지 않는다
+    private static final int PER_COMPANY_LOOKBACK_MONTHS = 12;
+
+    // yyyyMMdd 형식 날짜 포매터
+    private static final DateTimeFormatter BASIC_DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private final DartApiClient dartApiClient;
     private final CompanyRepository companyRepository;
@@ -41,16 +58,39 @@ public class DartIpoSyncService {
     private final IpoDisclosureReportRepository disclosureReportRepository;
     private final IpoDisclosureDocumentClassifier ipoDisclosureDocumentClassifier;
 
+    // 모든 IpoEvent의 status를 오늘 날짜 기준으로 다시 계산해 DB에 반영하는 메서드
+    // 일정 정보(청약·상장일)는 그대로인데 시간이 흘러 상태가 바뀌어야 하는 경우(UPCOMING → ONGOING → CLOSED → LISTED) 처리
+    // status 컬럼으로 필터하는 쿼리(findByStatus 등)가 stale 상태로 잘못된 결과 내는 걸 방지하기 위해 매일 자정 직후 일괄 호출
+    // company/offering/metric 같은 lazy 연관관계는 건드리지 않으므로 LazyInit 안전
+    @Transactional
+    public int refreshAllIpoStatuses() {
+        LocalDate today = LocalDate.now();
+        List<IpoEvent> allEvents = ipoEventRepository.findAll();
+        int updatedCount = 0;
+        for (IpoEvent event : allEvents) {
+            IpoEventStatus next = event.resolveStatus(today);
+            if (next != event.getStatus()) {
+                event.updateStatus(next);
+                updatedCount++;
+            }
+        }
+        return updatedCount;
+    }
+
     @Transactional
     // 특정 기업의 특정 기간 공모 관련 데이터를 동기화하는 메서드
     public void syncIpoByCompany(String corpCode, String beginDate, String endDate){
         Company company = companyRepository.findByCorpCode(corpCode) // corpCode로 기업을 조회
                 .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
 
+        // 기업별 조회는 최초 증권신고서를 놓치지 않도록 시작일을 과거로 넓힘
+        // (estkRs/공시검색이 최초접수일 기준으로 필터링되기 때문)
+        String wideBeginDate = widenBeginDate(beginDate, endDate);
+
         // DART 공시검색 API 호출
         // disclosureType -> null : 초기에는 전체 공시에서 reportNm 기준으로 증권신고서를 필터링하기 위함
         DartDisclosureSearchResponse disclosureSearchResponse = dartApiClient.searchDisclosure(
-                beginDate,
+                wideBeginDate,
                 endDate,
                 corpCode,
                 null,
@@ -67,7 +107,7 @@ public class DartIpoSyncService {
 
         // DART 지분증권 증권신고서 주요정보 API 호출: 청약기일, 납입기일, 인수기관명 등의 구조화 데이터를 얻기 위해 사용
         DartEquitySecuritiesReportResponse equityResponse =
-                dartApiClient.getEquitySecuritiesReport(corpCode, beginDate, endDate);
+                dartApiClient.getEquitySecuritiesReport(corpCode, wideBeginDate, endDate);
 
         if (equityResponse.getList() == null) {
             return; // 주요정보 목록이 없다면 더 처리할 데이터가 없으므로 메서드 종료
@@ -79,11 +119,46 @@ public class DartIpoSyncService {
         }
     }
 
+    // 기업별 조회 시작일을 PER_COMPANY_LOOKBACK_MONTHS만큼 과거로 넓히는 메서드
+    // 호출자가 더 넓은 범위를 줬다면 그 값을 그대로 사용
+    private String widenBeginDate(String beginDate, String endDate) {
+        LocalDate passedBegin = LocalDate.parse(beginDate, BASIC_DATE);
+        LocalDate widened = LocalDate.parse(endDate, BASIC_DATE).minusMonths(PER_COMPANY_LOOKBACK_MONTHS);
+        LocalDate effective = widened.isBefore(passedBegin) ? widened : passedBegin;
+        return effective.format(BASIC_DATE);
+    }
+
     // 시장 전체 발행공시를 검색해 공모주 관련 공시를 제출한 기업 고유번호(corpCode)를 수집하는 메서드
     // 스케줄러가 어떤 기업을 동기화해야 하는지 찾는 진입점으로 사용 (DB를 건드리지 않는 조회 전용)
+    // DART 시장 전체 검색은 조회 기간이 약 3개월로 제한되므로 기간을 분할해 검색한다
     public Set<String> findRecentIpoCorpCodes(String beginDate, String endDate) {
         Set<String> corpCodes = new LinkedHashSet<>();
 
+        LocalDate begin = LocalDate.parse(beginDate, BASIC_DATE);
+        LocalDate end = LocalDate.parse(endDate, BASIC_DATE);
+
+        // [begin, end]를 MAX_SEARCH_RANGE_DAYS 이하 구간으로 나눠 각 구간을 검색
+        LocalDate chunkStart = begin;
+        while (!chunkStart.isAfter(end)) {
+            LocalDate chunkEnd = chunkStart.plusDays(MAX_SEARCH_RANGE_DAYS);
+            if (chunkEnd.isAfter(end)) {
+                chunkEnd = end;
+            }
+
+            collectCorpCodesInRange(
+                    chunkStart.format(BASIC_DATE),
+                    chunkEnd.format(BASIC_DATE),
+                    corpCodes
+            );
+
+            chunkStart = chunkEnd.plusDays(1);
+        }
+
+        return corpCodes;
+    }
+
+    // 특정 기간의 시장 전체 발행공시를 페이지네이션하며 공모주 후보 기업 고유번호를 수집하는 메서드
+    private void collectCorpCodesInRange(String beginDate, String endDate, Set<String> corpCodes) {
         int pageNo = 1;
 
         while (pageNo <= MAX_SEARCH_PAGES) {
@@ -96,9 +171,12 @@ public class DartIpoSyncService {
                 break;
             }
 
-            // 공모주 관련 보고서명만 골라 기업 고유번호 수집
+            // 지분증권 증권신고서 + 상장 전 기타법인(E)만 골라 기업 고유번호 수집
+            // - 지분증권 필터: 채무증권(회사채) 등 비지분증권 증권신고서를 제외
+            // - corp_cls 필터: 기존 상장사의 유상증자·합병을 제외해 신규 IPO만 추림
             response.getList().stream()
-                    .filter(item -> ipoDisclosureDocumentClassifier.isIpoRelevantReportName(item.getReportNm()))
+                    .filter(item -> ipoDisclosureDocumentClassifier.isEquityOfferingReportName(item.getReportNm()))
+                    .filter(item -> NON_LISTED_CORP_CLASS.equals(item.getCorpCls()))
                     .map(DartDisclosureSearchResponse.Item::getCorpCode)
                     .filter(code -> code != null && !code.isBlank())
                     .forEach(corpCodes::add);
@@ -110,8 +188,6 @@ public class DartIpoSyncService {
 
             pageNo++;
         }
-
-        return corpCodes;
     }
 
     // 공시 검색 결과 1건을 ipo_disclosure_reports에 저장하거나 갱신하는 메서드
@@ -174,8 +250,8 @@ public class DartIpoSyncService {
                 allocationDate
         );
 
-        // 청약 시작/종료일 기준으로 공모 상태를 계산하여 갱신
-        ipoEvent.updateStatus(determineStatus(subscriptionStart, subscriptionEnd, null));
+        // 청약/상장 일정 기준으로 공모 상태를 계산하여 갱신
+        ipoEvent.updateStatus(ipoEvent.resolveStatus(LocalDate.now()));
 
         // 청약공고일, 배정기준일 등 공모 조건 보조 정보를 저장/갱신
         upsertOffering(ipoEvent, item);
@@ -184,13 +260,16 @@ public class DartIpoSyncService {
         upsertBroker(ipoEvent, item.getUdtintnm());
     }
 
-    // 접수번호를 기준으로 IpoEvent를 찾거나 새로 생성하는 메서드
+    // 기업을 기준으로 IpoEvent를 찾거나 새로 생성하는 메서드
+    // 한 기업의 IPO는 최초·정정 증권신고서, 투자설명서, 발행실적 등 여러 공시로 구성되므로
+    // 공시 접수번호(rceptNo) 단위가 아니라 기업 단위로 하나의 IpoEvent를 공유한다
     private IpoEvent findOrCreateIpoEvent(
             Company company,
             String rceptNo,
             String eventName
     ) {
-        return ipoEventRepository.findByMainReportRceptNo(rceptNo) // 대표 공시 접수번호 기준으로 기존 공모 이벤트 조회
+        return ipoEventRepository.findByCompanyId(company.getId()).stream()
+                .findFirst() // 해당 기업의 기존 공모 이벤트가 있으면 재사용
                 .orElseGet(() -> ipoEventRepository.save(
                         IpoEvent.builder()
                                 .company(company)
@@ -263,30 +342,6 @@ public class DartIpoSyncService {
                 );
             }
         }
-    }
-
-    // 청약일과 상장일을 기준으로 공모 이벤트 상태를 계산하는 내부 메서드
-    private IpoEventStatus determineStatus(
-            LocalDate subscriptionStart,
-            LocalDate subscriptionEnd,
-            LocalDate listingDate
-    ) {
-        LocalDate today = LocalDate.now(); // 오늘 날짜
-
-        if (listingDate != null && !listingDate.isAfter(today)) { // 상장일이 있고 상장일이 오늘 또는 과거라면 이미 상장된 상태
-            return IpoEventStatus.LISTED;
-        }
-
-        if (subscriptionStart != null && subscriptionEnd != null
-                && !today.isBefore(subscriptionStart)
-                && !today.isAfter(subscriptionEnd)) { // 오늘이 청약 시작일과 종료일 사이에 있으면 청약 진행중
-            return IpoEventStatus.ONGOING;
-        }
-
-        if (subscriptionEnd != null && subscriptionEnd.isBefore(today)) // 청약 종료일이 오늘보다 이전이면 청약은 마감된 상태
-            return IpoEventStatus.CLOSED;
-
-        return IpoEventStatus.UPCOMING; // 위 조건에 모두 해당하지 않으면 예정 상태
     }
 
 }

--- a/src/main/java/com/gong/modu/service/pipeline/DisclosureContextExtractor.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DisclosureContextExtractor.java
@@ -9,12 +9,17 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @Component
 @RequiredArgsConstructor
 // AI에게 보낼 공시 원문 일부 문맥을 추출하는 클래스
 public class DisclosureContextExtractor {
-    private static final int MAX_CONTEXT_LENGTH = 30_000;
+    // AI에게 전달할 최대 컨텍스트 길이
+    // 한글 30,000자에 6개 섹션을 다 담으려니 OFFERING_PROCEDURE 등 후순위 섹션이 잘리는 케이스 다수 발생
+    // 60,000자로 늘려도 Claude Sonnet 입력 비용은 공시 1건당 약 $0.08 수준이라 부담 적음
+    // (lost-in-the-middle 영향을 고려해 무한정 키우지 않고 적정선 유지)
+    private static final int MAX_CONTEXT_LENGTH = 60_000;
 
     // 같은 섹션 타입 간 중복 허용 임계값 (80% 이상 겹치면 제외)
     private static final double SAME_TYPE_OVERLAP_THRESHOLD = 0.8;
@@ -28,7 +33,8 @@ public class DisclosureContextExtractor {
             DisclosureSectionType.OFFERING_PROCEDURE,
             DisclosureSectionType.BOOKBUILDING_RESULT,
             DisclosureSectionType.OFFER_PRICE_DECISION,
-            DisclosureSectionType.LOCKUP
+            DisclosureSectionType.LOCKUP,
+            DisclosureSectionType.UNDERWRITER
     );
 
     // 섹션 추출 실패 시 fallback으로 사용할 키워드 목록
@@ -48,6 +54,36 @@ public class DisclosureContextExtractor {
             "상장예정주식수"
     );
 
+    // 잘리지 않도록 컨텍스트 맨 앞에 무조건 주입할 핵심 키워드들
+    // (특히 상장예정일·매매개시일은 OFFERING_PROCEDURE 섹션 우선순위가 낮아서 자주 잘림)
+    // 동일 키워드가 규정 텍스트에 수십 번 나오므로, 윈도우에 실제 한국 날짜 패턴이 포함된 것만 채택
+    private static final List<String> CRITICAL_KEYWORDS = List.of(
+            "상장예정일",
+            "상장 예정일",
+            "상장(예정)일",
+            "매매개시일",
+            "신규상장일",
+            "신규상장",
+            "상장일",
+            "공모일정",
+            "주요일정",
+            "주요 일정",
+            "공모 일정"
+    );
+
+    // 핵심 키워드 주변에 잡을 윈도우 크기 (앞 300자 + 뒤 1500자)
+    private static final int CRITICAL_WINDOW_BEFORE = 300;
+    private static final int CRITICAL_WINDOW_AFTER = 1500;
+
+    // 핵심 키워드 컨텍스트가 사용할 최대 예산 (전체 60000자 중 일부 우선 할당)
+    private static final int CRITICAL_CONTEXT_BUDGET = 8000;
+
+    // 한국 IPO 공시에서 자주 쓰이는 날짜 표기 패턴
+    // yyyy년 m월 d일 / yyyy.m.d / yyyy-m-d / yyyy/m/d 모두 매치
+    private static final Pattern KOREAN_DATE_PATTERN = Pattern.compile(
+            "\\d{4}\\s*[년./\\-]\\s*\\d{1,2}\\s*[월./\\-]\\s*\\d{1,2}\\s*일?"
+    );
+
     private final DisclosureSectionExtractor disclosureSectionExtractor;
 
     // 공시 원문에서 AI 파싱에 필요한 섹션 문맥을 추출하는 메서드
@@ -55,11 +91,16 @@ public class DisclosureContextExtractor {
         if (originalText == null || originalText.isBlank())
             return "";
 
+        // 1) 상장예정일/매매개시일 등 핵심 키워드 주변을 먼저 뽑아 컨텍스트 맨 앞에 고정 배치
+        //    (섹션 추출 우선순위에 밀려 잘리는 케이스 방어)
+        String criticalContext = extractCriticalKeywordContext(originalText);
+
         List<DisclosureSection> sections =
                 disclosureSectionExtractor.extractSectionByTypes(originalText, ALL_SECTION_TYPES);
 
         if (sections.isEmpty()) {
-            return extractFallbackKeywordContext(originalText);
+            String fallback = extractFallbackKeywordContext(originalText);
+            return prependCriticalContext(criticalContext, fallback);
         }
 
         List<DisclosureSection> selected = selectNonOverlappingSections(sections);
@@ -74,11 +115,61 @@ public class DisclosureContextExtractor {
         // 섹션 추출 후 남은 예산으로 문서 후반부를 추가해 미발견 구간을 커버
         joined = appendTailCoverageIfBudgetRemains(joined, originalText, selected);
 
-        if (joined.length() > MAX_CONTEXT_LENGTH) {
-            return joined.substring(0, MAX_CONTEXT_LENGTH);
+        String withCritical = prependCriticalContext(criticalContext, joined);
+
+        if (withCritical.length() > MAX_CONTEXT_LENGTH) {
+            return withCritical.substring(0, MAX_CONTEXT_LENGTH);
         }
 
-        return joined;
+        return withCritical;
+    }
+
+    // 핵심 키워드(상장예정일/매매개시일 등) 주변 텍스트를 모아 컨텍스트 맨 앞에 붙이는 메서드
+    // 윈도우 안에 실제 한국 날짜 패턴이 있는 경우만 채택 (규정·법령 인용문 필터링)
+    private String extractCriticalKeywordContext(String originalText) {
+        String normalized = normalize(originalText);
+
+        Set<String> windows = new LinkedHashSet<>();
+
+        for (String keyword : CRITICAL_KEYWORDS) {
+            int fromIndex = 0;
+            while (fromIndex < normalized.length()) {
+                int keywordIndex = normalized.indexOf(keyword, fromIndex);
+                if (keywordIndex < 0) break;
+
+                int start = Math.max(0, keywordIndex - CRITICAL_WINDOW_BEFORE);
+                int end = Math.min(normalized.length(), keywordIndex + CRITICAL_WINDOW_AFTER);
+                String window = normalized.substring(start, end);
+
+                // 윈도우 안에 한국 날짜 패턴이 있어야만 채택 (실제 일정표 vs 규정 텍스트 구분)
+                if (KOREAN_DATE_PATTERN.matcher(window).find()) {
+                    windows.add(window);
+                }
+
+                fromIndex = keywordIndex + keyword.length();
+            }
+        }
+
+        if (windows.isEmpty()) return "";
+
+        String joined = String.join("\n---\n", windows);
+
+        if (joined.length() > CRITICAL_CONTEXT_BUDGET) {
+            joined = joined.substring(0, CRITICAL_CONTEXT_BUDGET);
+        }
+
+        return "[CRITICAL_KEYWORDS: 일정표(상장예정일/매매개시일/공모일정 + 날짜 포함) 발췌]\n" + joined;
+    }
+
+    // 핵심 키워드 컨텍스트를 메인 컨텍스트 앞에 결합하는 메서드
+    private String prependCriticalContext(String criticalContext, String mainContext) {
+        if (criticalContext == null || criticalContext.isEmpty()) {
+            return mainContext;
+        }
+        if (mainContext == null || mainContext.isEmpty()) {
+            return criticalContext;
+        }
+        return criticalContext + "\n\n=== END OF CRITICAL KEYWORDS ===\n\n" + mainContext;
     }
 
     // 디버깅용: 실제로 AI에게 전달되는 섹션 목록과 동일한 필터를 적용해 반환

--- a/src/main/java/com/gong/modu/service/pipeline/DisclosureParsingExecutor.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DisclosureParsingExecutor.java
@@ -1,0 +1,197 @@
+package com.gong.modu.service.pipeline;
+
+import com.gong.modu.client.DartApiClient;
+import com.gong.modu.domain.dto.pipeline.AiDisclosureParsingResult;
+import com.gong.modu.domain.dto.pipeline.IpoDisclosureParsingResult;
+import com.gong.modu.domain.entity.ipo.IpoDisclosureReport;
+import com.gong.modu.domain.entity.ipo.IpoEvent;
+import com.gong.modu.domain.entity.ipo.IpoMetric;
+import com.gong.modu.domain.entity.ipo.IpoOffering;
+import com.gong.modu.domain.enums.ipo.DisclosureDocumentType;
+import com.gong.modu.exception.CustomException;
+import com.gong.modu.exception.ErrorCode;
+import com.gong.modu.repository.ipo.IpoDisclosureReportRepository;
+import com.gong.modu.repository.ipo.IpoEventRepository;
+import com.gong.modu.repository.ipo.IpoMetricRepository;
+import com.gong.modu.repository.ipo.IpoOfferingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+// parseDisclosureReport()를 별도 컴포넌트로 분리하여 Spring AOP 프록시를 통한 @Transactional이 정상 동작하도록 함
+// DartDisclosureParsingService에서 self-invocation으로 호출하면 트랜잭션이 무효화되는 문제를 해결
+public class DisclosureParsingExecutor {
+
+    private final DartApiClient dartApiClient;
+    private final DisclosureTextExtractor disclosureTextExtractor;
+    private final IpoEventRepository ipoEventRepository;
+    private final IpoOfferingRepository ipoOfferingRepository;
+    private final IpoMetricRepository ipoMetricRepository;
+    private final IpoDisclosureReportRepository disclosureReportRepository;
+    private final IpoDisclosureDocumentClassifier ipoDisclosureDocumentClassifier;
+    private final DisclosureContextExtractor disclosureContextExtractor;
+    private final AiDisclosureParsingService aiDisclosureParsingService;
+    private final DisclosureParsingResultMerger disclosureParsingResultMerger;
+    private final IpoBrokerWriter ipoBrokerWriter;
+
+    @Transactional
+    public void parseDisclosureReport(Long ipoEventId, String rceptNo) {
+        IpoEvent ipoEvent = ipoEventRepository.findById(ipoEventId)
+                .orElseThrow(() -> new CustomException(ErrorCode.IPO_EVENT_NOT_FOUND));
+
+        byte[] zipBytes = dartApiClient.downloadDisclosureDocumentZip(rceptNo);
+        String originalText = disclosureTextExtractor.extractTextFromZip(zipBytes);
+
+        if (originalText == null || originalText.isBlank()) {
+            throw new CustomException(ErrorCode.DISCLOSURE_PARSING_FAILED);
+        }
+
+        DisclosureDocumentType documentType =
+                ipoDisclosureDocumentClassifier.detectDocumentType(originalText);
+
+        upsertDisclosureOriginalText(ipoEvent, rceptNo, originalText, documentType);
+
+        if (documentType == DisclosureDocumentType.NON_IPO_DOCUMENT) {
+            log.info(
+                    "[DART Disclosure Parsing] IPO 관련 공시가 아니므로 값 파싱 건너뜀: rceptNo={}, documentType={}",
+                    rceptNo,
+                    documentType
+            );
+            return;
+        }
+
+        String aiContext = disclosureContextExtractor.extractContext(originalText);
+
+        AiDisclosureParsingResult aiResult = null;
+        if (aiContext != null && !aiContext.isBlank()) {
+            aiResult = aiDisclosureParsingService.parseWithAi(aiContext);
+        }
+
+        IpoDisclosureParsingResult parsingResult =
+                disclosureParsingResultMerger.toResult(aiResult);
+
+        applyParsingResult(ipoEvent, parsingResult);
+    }
+
+    private IpoDisclosureReport upsertDisclosureOriginalText(
+            IpoEvent ipoEvent,
+            String rceptNo,
+            String originalText,
+            DisclosureDocumentType documentType
+    ) {
+        return disclosureReportRepository.findByIpoEventIdAndRceptNo(ipoEvent.getId(), rceptNo)
+                .map(existing -> {
+                    existing.updateOriginalText(originalText);
+                    existing.updateDocumentType(documentType);
+                    return existing;
+                })
+                .orElseGet(() -> disclosureReportRepository.save(
+                        IpoDisclosureReport.builder()
+                                .ipoEvent(ipoEvent)
+                                .rceptNo(rceptNo)
+                                .reportName("DART 원문 공시")
+                                .documentType(documentType)
+                                .originalText(originalText)
+                                .build()
+                ));
+    }
+
+    // 청약 종료 후 한국 IPO 상장까지 통상 소요 일수 (거래소 상장승인 절차 포함)
+    // 발행조건확정 공시에 실제 상장일이 안 적혀있는 케이스가 많아 추정값으로 채워두고,
+    // 추후 증권발행실적보고서에서 실제 상장일이 파싱되면 자동 덮어쓰기
+    private static final int LISTING_DATE_OFFSET_DAYS_FROM_SUBSCRIPTION_END = 7;
+
+    private void applyParsingResult(IpoEvent ipoEvent, IpoDisclosureParsingResult result) {
+        // 1) listingDate: AI 추출값 우선
+        //    - 실제 추출 → estimated=false (확정값으로 덮어쓰기)
+        //    - AI는 null인데 기존 값이 없거나 기존 값도 추정값이면 → 새 데이터로 다시 추정
+        //      (subscriptionEndDate가 정정되면 listingDate 추정값도 함께 갱신됨)
+        //    - AI는 null이고 기존이 확정값이면 → 그대로 유지
+        LocalDate effectiveListingDate = result.getListingDate();
+        Boolean listingDateEstimatedFlag = null;
+        if (effectiveListingDate != null) {
+            listingDateEstimatedFlag = false;
+        } else if (ipoEvent.getListingDate() == null
+                || Boolean.TRUE.equals(ipoEvent.getListingDateEstimated())) {
+            LocalDate baseSubEnd = result.getSubscriptionEnd() != null
+                    ? result.getSubscriptionEnd()
+                    : ipoEvent.getSubscriptionEndDate();
+            if (baseSubEnd != null) {
+                effectiveListingDate = baseSubEnd.plusDays(LISTING_DATE_OFFSET_DAYS_FROM_SUBSCRIPTION_END);
+                listingDateEstimatedFlag = true;
+            }
+        }
+
+        // 2) lockupExpiryDate: AI 직접 추출값 우선
+        //    - AI 직접 추출 → estimated=false
+        //    - AI는 null인데 lockupPeriodMonths가 있고 기존이 없거나 추정값이면 → 다시 계산
+        //    - listingDate가 갱신됐어도 lockupPeriodMonths가 이번 result에 없으면 lockup은 그대로 (다음 파싱 때 자연스럽게 수렴)
+        LocalDate lockupExpiryDate = result.getLockupExpiryDate();
+        Boolean lockupExpiryEstimatedFlag = null;
+        if (lockupExpiryDate != null) {
+            lockupExpiryEstimatedFlag = false;
+        } else if (result.getLockupPeriodMonths() != null
+                && (ipoEvent.getLockupExpiryDate() == null
+                        || Boolean.TRUE.equals(ipoEvent.getLockupExpiryDateEstimated()))) {
+            LocalDate baseListingDate = effectiveListingDate != null
+                    ? effectiveListingDate
+                    : ipoEvent.getListingDate();
+            if (baseListingDate != null) {
+                lockupExpiryDate = baseListingDate.plusMonths(result.getLockupPeriodMonths());
+                lockupExpiryEstimatedFlag = true;
+            }
+        }
+
+        ipoEvent.updateParsedSchedule(
+                result.getDemandForecastStart(),
+                result.getDemandForecastEnd(),
+                result.getSubscriptionStart(),
+                result.getSubscriptionEnd(),
+                result.getRefundDate(),
+                effectiveListingDate,
+                lockupExpiryDate
+        );
+
+        // 값이 갱신된 경우에만 추정 플래그도 함께 변경
+        ipoEvent.markListingDateEstimated(listingDateEstimatedFlag);
+        ipoEvent.markLockupExpiryDateEstimated(lockupExpiryEstimatedFlag);
+
+        ipoEvent.updateStatus(ipoEvent.resolveStatus(LocalDate.now()));
+
+        IpoOffering offering = ipoOfferingRepository.findByIpoEventId(ipoEvent.getId())
+                .orElseGet(() -> ipoOfferingRepository.save(
+                        IpoOffering.builder()
+                                .ipoEvent(ipoEvent)
+                                .build()
+                ));
+
+        offering.updateParsedOfferingInfo(
+                result.getShareCount(),
+                result.getTotalListedShares(),
+                result.getOfferPriceMin(),
+                result.getOfferPriceMax(),
+                result.getOfferPrice()
+        );
+
+        IpoMetric metric = ipoMetricRepository.findByIpoEventId(ipoEvent.getId())
+                .orElseGet(() -> ipoMetricRepository.save(
+                        IpoMetric.builder()
+                                .ipoEvent(ipoEvent)
+                                .build()
+                ));
+
+        metric.updateParsedMetrics(
+                result.getInstitutionalCompetitionRate(),
+                result.getLockupRatio(),
+                result.getProtectiveCustodyRatio()
+        );
+
+        ipoBrokerWriter.upsertBrokers(ipoEvent, result.getBrokerNames());
+    }
+}

--- a/src/main/java/com/gong/modu/service/pipeline/DisclosureParsingResultMerger.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DisclosureParsingResultMerger.java
@@ -23,9 +23,12 @@ public class DisclosureParsingResultMerger {
         return IpoDisclosureParsingResult.builder()
                 .demandForecastStart(parseAiDate(aiResult.getDemandForecastStart()))
                 .demandForecastEnd(parseAiDate(aiResult.getDemandForecastEnd()))
+                .subscriptionStart(parseAiDate(aiResult.getSubscriptionStart()))
+                .subscriptionEnd(parseAiDate(aiResult.getSubscriptionEnd()))
                 .refundDate(parseAiDate(aiResult.getRefundDate()))
                 .listingDate(parseAiDate(aiResult.getListingDate()))
                 .lockupExpiryDate(parseAiDate(aiResult.getLockupExpiryDate()))
+                .lockupPeriodMonths(validPositiveInt(aiResult.getLockupPeriodMonths()))
                 .offerPriceMin(validMoney(aiResult.getOfferPriceMin()))
                 .offerPriceMax(validMoney(aiResult.getOfferPriceMax()))
                 .offerPrice(validMoney(aiResult.getOfferPrice()))
@@ -34,6 +37,7 @@ public class DisclosureParsingResultMerger {
                 .institutionalCompetitionRate(validMoney(aiResult.getInstitutionalCompetitionRate()))
                 .lockupRatio(validRatio(aiResult.getLockupRatio()))
                 .protectiveCustodyRatio(validRatio(aiResult.getProtectiveCustodyRatio()))
+                .brokerNames(aiResult.getBrokerNames())
                 .build();
     }
 
@@ -82,6 +86,17 @@ public class DisclosureParsingResultMerger {
 
     // Long 값이 0보다 큰지 검증하는 메서드
     private Long validPositiveLong(Long value) {
+        if (value == null)
+            return null;
+
+        if (value <= 0)
+            return null;
+
+        return value;
+    }
+
+    // Integer 값이 0보다 큰지 검증하는 메서드
+    private Integer validPositiveInt(Integer value) {
         if (value == null)
             return null;
 

--- a/src/main/java/com/gong/modu/service/pipeline/IpoBrokerWriter.java
+++ b/src/main/java/com/gong/modu/service/pipeline/IpoBrokerWriter.java
@@ -1,0 +1,65 @@
+package com.gong.modu.service.pipeline;
+
+import com.gong.modu.domain.entity.ipo.Broker;
+import com.gong.modu.domain.entity.ipo.IpoEvent;
+import com.gong.modu.domain.entity.ipo.IpoEventBroker;
+import com.gong.modu.domain.enums.ipo.BrokerRole;
+import com.gong.modu.repository.ipo.BrokerRepository;
+import com.gong.modu.repository.ipo.IpoEventBrokerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+// 증권사명 목록을 Broker 마스터와 IpoEventBroker 연결 정보로 저장하는 컴포넌트
+// 공시 파싱 결과의 주관사 목록을 공모 이벤트에 반영할 때 사용
+@Component
+@RequiredArgsConstructor
+public class IpoBrokerWriter {
+
+    private final BrokerRepository brokerRepository;
+    private final IpoEventBrokerRepository ipoEventBrokerRepository;
+
+    // 증권사명 목록을 받아 해당 공모 이벤트의 IpoEventBroker로 저장하는 메서드 (이미 연결된 증권사는 건너뜀)
+    public void upsertBrokers(IpoEvent ipoEvent, List<String> brokerNames) {
+        if (brokerNames == null || brokerNames.isEmpty()) {
+            return;
+        }
+
+        // 이미 이 공모 이벤트에 연결된 증권사명 목록
+        List<IpoEventBroker> existing = ipoEventBrokerRepository.findByIpoEventId(ipoEvent.getId());
+
+        for (String rawName : brokerNames) {
+            if (rawName == null || rawName.isBlank()) {
+                continue;
+            }
+
+            String brokerName = rawName.trim();
+
+            // 이미 연결된 증권사면 건너뜀
+            boolean alreadyLinked = existing.stream()
+                    .anyMatch(eventBroker -> brokerName.equals(eventBroker.getBrokerName()));
+
+            if (alreadyLinked) {
+                continue;
+            }
+
+            // 증권사 마스터는 이름 기준으로 찾거나 새로 생성
+            Broker broker = brokerRepository.findByName(brokerName)
+                    .orElseGet(() -> brokerRepository.save(
+                            Broker.builder()
+                                    .name(brokerName)
+                                    .build()
+                    ));
+
+            ipoEventBrokerRepository.save(
+                    IpoEventBroker.builder()
+                            .ipoEvent(ipoEvent)
+                            .broker(broker)
+                            .brokerName(brokerName)
+                            .role(BrokerRole.UNDERWRITER) // 기본 역할은 인수회사로 설정
+                            .build()
+            );
+        }
+    }
+}

--- a/src/main/java/com/gong/modu/service/pipeline/IpoDisclosureDocumentClassifier.java
+++ b/src/main/java/com/gong/modu/service/pipeline/IpoDisclosureDocumentClassifier.java
@@ -193,6 +193,19 @@ public class IpoDisclosureDocumentClassifier {
         return hasIpoReportType || hasIpoKeyword;
     }
 
+    // reportNm이 지분증권 증권신고서 계열(신규 IPO)인지 판단하는 메서드
+    // 시장 전체 발견 단계에서 채무증권 등 비지분증권 공시를 제외하기 위해 사용
+    public boolean isEquityOfferingReportName(String reportName) {
+        if (reportName == null || reportName.isBlank()) {
+            return false;
+        }
+
+        String name = reportName.trim();
+
+        // 증권신고서(지분증권), [기재정정]증권신고서(지분증권), [발행조건확정]증권신고서(지분증권) 등을 매칭
+        return name.contains("증권신고서") && name.contains("지분증권");
+    }
+
     private String normalize(String text) {
         return text.replaceAll("\\s+", " ").trim();
     }

--- a/src/main/java/com/gong/modu/service/user/InterestIpoService.java
+++ b/src/main/java/com/gong/modu/service/user/InterestIpoService.java
@@ -1,0 +1,126 @@
+package com.gong.modu.service.user;
+
+import com.gong.modu.domain.dto.user.InterestIpoItemResponse;
+import com.gong.modu.domain.entity.ipo.IpoEvent;
+import com.gong.modu.domain.entity.ipo.IpoEventBroker;
+import com.gong.modu.domain.entity.ipo.IpoOffering;
+import com.gong.modu.domain.entity.user.User;
+import com.gong.modu.domain.entity.user.UserInterestIpo;
+import com.gong.modu.exception.CustomException;
+import com.gong.modu.exception.ErrorCode;
+import com.gong.modu.repository.ipo.IpoEventBrokerRepository;
+import com.gong.modu.repository.ipo.IpoEventRepository;
+import com.gong.modu.repository.user.UserInterestIpoRepository;
+import com.gong.modu.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+// 관심 공모주(찜) 등록/해제/조회를 담당하는 서비스
+// 기능명세서 5.1.2 관심 공모주 참고
+@Service
+@RequiredArgsConstructor
+public class InterestIpoService {
+
+    private final UserRepository userRepository;
+    private final IpoEventRepository ipoEventRepository;
+    private final UserInterestIpoRepository userInterestIpoRepository;
+    private final IpoEventBrokerRepository ipoEventBrokerRepository;
+
+    // 특정 공모주를 사용자의 관심 목록에 등록
+    @Transactional
+    public Long addInterest(Long userId, Long ipoEventId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        IpoEvent ipoEvent = ipoEventRepository.findById(ipoEventId)
+                .orElseThrow(() -> new CustomException(ErrorCode.IPO_EVENT_NOT_FOUND));
+
+        if (userInterestIpoRepository.existsByUserAndIpoEventId(user, ipoEventId)) {
+            throw new CustomException(ErrorCode.ALREADY_INTERESTED_IPO);
+        }
+
+        UserInterestIpo saved = userInterestIpoRepository.save(
+                UserInterestIpo.builder()
+                        .user(user)
+                        .ipoEvent(ipoEvent)
+                        .build()
+        );
+
+        return saved.getId();
+    }
+
+    // 특정 공모주를 사용자의 관심 목록에서 해제
+    @Transactional
+    public void removeInterest(Long userId, Long ipoEventId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        UserInterestIpo target = userInterestIpoRepository.findByUserAndIpoEventId(user, ipoEventId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INTERESTED_IPO_NOT_FOUND));
+
+        userInterestIpoRepository.delete(target);
+    }
+
+    // 사용자의 관심 공모주 목록을 최신 등록순으로 조회
+    @Transactional(readOnly = true)
+    public List<InterestIpoItemResponse> getMyInterests(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<UserInterestIpo> interests = userInterestIpoRepository.findByUserOrderByCreatedAtDesc(user);
+        LocalDate today = LocalDate.now();
+
+        return interests.stream()
+                .map(interest -> toItemResponse(interest, today))
+                .toList();
+    }
+
+    // 로그인 사용자의 관심 등록된 IpoEvent ID Set을 한 번에 조회
+    // 홈 화면에서 isFavorited 표시 시 N+1 쿼리를 막기 위한 용도
+    @Transactional(readOnly = true)
+    public Set<Long> getInterestedIpoEventIds(Long userId) {
+        if (userId == null) {
+            return Set.of();
+        }
+
+        return userRepository.findById(userId)
+                .map(user -> userInterestIpoRepository.findByUser(user).stream()
+                        .map(interest -> interest.getIpoEvent().getId())
+                        .collect(Collectors.toSet()))
+                .orElse(Set.of());
+    }
+
+    private InterestIpoItemResponse toItemResponse(UserInterestIpo interest, LocalDate today) {
+        IpoEvent event = interest.getIpoEvent();
+        IpoOffering offering = event.getOffering();
+
+        List<String> brokerNames = ipoEventBrokerRepository.findByIpoEventId(event.getId()).stream()
+                .map(IpoEventBroker::getBrokerName)
+                .distinct()
+                .toList();
+
+        return InterestIpoItemResponse.builder()
+                .interestId(interest.getId())
+                .ipoEventId(event.getId())
+                .companyName(event.getCompany().getCorpName())
+                .status(event.resolveStatus(today))
+                .subscriptionStartDate(event.getSubscriptionStartDate())
+                .subscriptionEndDate(event.getSubscriptionEndDate())
+                .listingDate(event.getListingDate())
+                .listingDateEstimated(event.getListingDateEstimated())
+                .lockupExpiryDate(event.getLockupExpiryDate())
+                .lockupExpiryDateEstimated(event.getLockupExpiryDateEstimated())
+                .offerPriceMin(offering == null ? null : offering.getOfferPriceMin())
+                .offerPriceMax(offering == null ? null : offering.getOfferPriceMax())
+                .offerPrice(offering == null ? null : offering.getOfferPrice())
+                .brokerNames(brokerNames)
+                .interestedAt(interest.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/gong/modu/service/user/SubscriptionHistoryService.java
+++ b/src/main/java/com/gong/modu/service/user/SubscriptionHistoryService.java
@@ -1,0 +1,150 @@
+package com.gong.modu.service.user;
+
+import com.gong.modu.domain.dto.user.*;
+import com.gong.modu.domain.entity.ipo.IpoEvent;
+import com.gong.modu.domain.entity.user.User;
+import com.gong.modu.domain.entity.user.UserSubscriptionHistory;
+import com.gong.modu.domain.enums.ipo.SubscriptionRecordStatus;
+import com.gong.modu.exception.CustomException;
+import com.gong.modu.exception.ErrorCode;
+import com.gong.modu.repository.ipo.IpoEventRepository;
+import com.gong.modu.repository.user.UserRepository;
+import com.gong.modu.repository.user.UserSubscriptionHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+// 청약 이력 (4.1 과거 투자 이력 + 4.2 현재 청약 중 이력) 관리 서비스
+@Service
+@RequiredArgsConstructor
+public class SubscriptionHistoryService {
+
+    private final UserRepository userRepository;
+    private final IpoEventRepository ipoEventRepository;
+    private final UserSubscriptionHistoryRepository historyRepository;
+
+    // 4.1 과거 투자 이력 생성 (DB 종목 조회 없이 사용자 직접 입력, status = COMPLETED)
+    @Transactional
+    public Long createCompleted(Long userId, CompletedHistoryCreateRequest request) {
+        User user = getUser(userId);
+
+        UserSubscriptionHistory history = UserSubscriptionHistory.builder()
+                .user(user)
+                .recordStatus(SubscriptionRecordStatus.COMPLETED)
+                .inputStockName(request.getInputStockName())
+                .inputCompanyName(request.getInputCompanyName())
+                .securityCompany(request.getSecurityCompany())
+                .subscribedQuantity(request.getSubscribedQuantity())
+                .allocatedQuantity(request.getAllocatedQuantity())
+                .sellPrice(request.getSellPrice())
+                .fee(request.getFee())
+                .tax(request.getTax())
+                .sellDate(request.getSellDate())
+                .memo(request.getMemo())
+                .build();
+
+        return historyRepository.save(history).getId();
+    }
+
+    // 4.2 현재 청약 중 이력 생성 (IpoEvent와 연결 필수, status = ONGOING)
+    @Transactional
+    public Long createOngoing(Long userId, OngoingHistoryCreateRequest request) {
+        User user = getUser(userId);
+
+        IpoEvent ipoEvent = ipoEventRepository.findById(request.getIpoEventId())
+                .orElseThrow(() -> new CustomException(ErrorCode.IPO_EVENT_NOT_FOUND));
+
+        UserSubscriptionHistory history = UserSubscriptionHistory.builder()
+                .user(user)
+                .ipoEvent(ipoEvent)
+                .recordStatus(SubscriptionRecordStatus.ONGOING)
+                .securityCompany(request.getSecurityCompany())
+                .subscribedQuantity(request.getSubscribedQuantity())
+                .offerPrice(request.getOfferPrice())
+                .subscriptionAmount(request.getSubscriptionAmount())
+                .memo(request.getMemo())
+                .build();
+
+        return historyRepository.save(history).getId();
+    }
+
+    // 내 청약 이력 전체 또는 상태별 조회 (최신순)
+    @Transactional(readOnly = true)
+    public List<SubscriptionHistoryResponse> getMyHistories(Long userId, SubscriptionRecordStatus status) {
+        User user = getUser(userId);
+
+        List<UserSubscriptionHistory> histories = (status == null)
+                ? historyRepository.findByUserOrderByCreatedAtDesc(user)
+                : historyRepository.findByUserAndRecordStatus(user, status);
+
+        return histories.stream()
+                .map(SubscriptionHistoryResponse::from)
+                .toList();
+    }
+
+    // 단건 조회
+    @Transactional(readOnly = true)
+    public SubscriptionHistoryResponse getHistory(Long userId, Long historyId) {
+        UserSubscriptionHistory history = findOwnedHistory(userId, historyId);
+        return SubscriptionHistoryResponse.from(history);
+    }
+
+    // 청약 이력 수정 (null인 필드는 기존 값 유지)
+    @Transactional
+    public void updateHistory(Long userId, Long historyId, SubscriptionHistoryUpdateRequest request) {
+        UserSubscriptionHistory history = findOwnedHistory(userId, historyId);
+
+        history.updateUserEditableFields(
+                request.getInputStockName(),
+                request.getInputCompanyName(),
+                request.getSecurityCompany(),
+                request.getSubscribedQuantity(),
+                request.getAllocatedQuantity(),
+                request.getOfferPrice(),
+                request.getSubscriptionAmount(),
+                request.getSellPrice(),
+                request.getFee(),
+                request.getTax(),
+                request.getSellDate(),
+                request.getMemo()
+        );
+    }
+
+    // ONGOING 이력에 매도 정보를 입력해 COMPLETED 로 전환
+    @Transactional
+    public void completeHistory(Long userId, Long historyId, CompleteHistoryRequest request) {
+        UserSubscriptionHistory history = findOwnedHistory(userId, historyId);
+
+        history.completeRecord(
+                request.getSellPrice(),
+                request.getFee(),
+                request.getTax(),
+                request.getSellDate()
+        );
+    }
+
+    // 삭제
+    @Transactional
+    public void deleteHistory(Long userId, Long historyId) {
+        UserSubscriptionHistory history = findOwnedHistory(userId, historyId);
+        historyRepository.delete(history);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private UserSubscriptionHistory findOwnedHistory(Long userId, Long historyId) {
+        UserSubscriptionHistory history = historyRepository.findById(historyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBSCRIPTION_HISTORY_NOT_FOUND));
+
+        if (!history.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.SUBSCRIPTION_HISTORY_FORBIDDEN);
+        }
+
+        return history;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #40 #41 #42 

## 📝작업 내용

- 5.1.2 관심 공모주(찜) + 4.1·4.2 청약이력 관리 API 추가
- 홈 화면 listingDate / lockupExpiryDate 추정값 + estimated 플래그로 빈 값 문제 해결
- 신호등 null 사유(SPAC / 수요예측 전 / 데이터 부족) 응답 필드 추가
- 공시 파싱 파이프라인 병렬화 + 매일 03:00 활성 IPO 자동 재파싱
- CI/CD 안정화 (git 강제 동기화, plain jar 제거, 누락 env 변수 추가)

### 스크린샷 

- 홈 조회

<img width="1370" height="660" alt="스크린샷 2026-05-24 13 04 38" src="https://github.com/user-attachments/assets/dc75786c-8a46-4dba-9a25-315813537d13" />

- 청약이력 CRUD

<img width="876" height="437" alt="스크린샷 2026-05-24 13 06 02" src="https://github.com/user-attachments/assets/0b21d189-e6ea-4a19-b500-7af8078101ce" />

- 관심공모주 CRD

<img width="456" height="211" alt="스크린샷 2026-05-24 13 06 35" src="https://github.com/user-attachments/assets/7f27cab7-17db-42a7-8afd-8d4a280a660d" />

## 변경 배경
홈 화면에서 발행조건확정 직후 IPO가 상장일/락업해제일 null로 표시되던 문제와,
코드 개선이 기존 데이터에 자동 반영되지 않아 매번 수동 재파싱이 필요했던 문제 해결.
청약이력·관심공모주 기능을 함께 마무리.

## 주요 변경

### 홈 응답(IpoHomeItemResponse) 확장
- `listingDate` + `listingDateEstimated`: 공시에 상장일 없으면 청약종료일 +7일로 추정
- `lockupExpiryDate` + `lockupExpiryDateEstimated`: AI 추출값 우선, 없으면 listingDate + lockupPeriodMonths 계산
- `signalUnavailableReason`: SPAC / PRE_DEMAND_FORECAST / INCOMPLETE_DATA
- `favorited`: 로그인 사용자의 찜 여부 (비로그인 시 false)

### 파이프라인 안정화
- `DartDisclosureParsingService` self-invocation 으로 @Transactional 무효화되던 버그 → `DisclosureParsingExecutor` 분리
- 같은 IPO 내 공시는 순차, 다른 IPO끼리만 병렬 (race condition 방지)
- `DisclosureContextExtractor` 컨텍스트 30K → 60K, 상장예정일 키워드 + 한국 날짜 패턴 윈도우 우선 주입
- AI 프롬프트 원칙 11(락업) / 15(상장일) 강화, `lockupPeriodMonths` 필드 추가

### 신규 스케줄러
- 매일 00:30 IPO 상태 자동 갱신 (시간 흐름에 따른 상태 전이)
- 매일 03:00 활성 IPO 일괄 재파싱 (status != LISTED 또는 estimated=true)

### CI/CD 안정화
- `set -ex` + `git fetch + reset --hard` 로 EC2 강제 동기화 (silent fail 방지)
- `build.gradle` plain jar 비활성화 (Dockerfile 와일드카드 모호성 제거)
- `docker-compose.yml` 누락 env 변수 5종 추가 (ADMIN_YOUTUBE_KEY 등)

### Swagger
- `IpoController`, `InterestIpoController`, `SubscriptionHistoryController` 에 @Tag / @Operation
- 모든 신규 Request / Response DTO 필드에 @Schema 한국어 설명

## DB 변경
`ddl-auto=update` 로 자동 적용:
- `ipo_events`: `listing_date_estimated`, `lockup_expiry_date_estimated` 컬럼 추가
- 기타 신규 테이블 없음 (UserInterestIpo / UserSubscriptionHistory 엔티티는 기존 존재)

## Test Plan
- [ ] 빌드 통과 + 신규 컬럼 자동 생성 확인
- [ ] GET `/api/ipo/home` → listingDate / lockupExpiryDate / favorited / signalUnavailableReason 응답 확인
- [ ] 로그인 후 POST `/api/interest-ipos/{id}` → 홈에서 favorited=true 확인
- [ ] GET `/api/ipo/search?keyword=피스피스` → ipoEventId 반환 → POST `/api/subscription-history/ongoing`
- [ ] POST `/api/subscription-history/completed` (inputStockName 필수 검증)
- [ ] 다른 사용자 이력 접근 → 403 SUBSCRIPTION_HISTORY_FORBIDDEN
- [ ] POST `/api/test/disclosure-parser/reparse-all-active` 후 estimated 플래그 채워지는지
- [ ] EC2 배포 후 새벽 03:00 활성 IPO 재파싱 스케줄러 로그 확인

## 운영 참고
- Claude API 크레딧 한도 도달 시 AI 파싱은 실패하지만 데이터 손상 없음 (기존 값 유지)
- `/api/test/disclosure-parser/*` 는 local·local-test 프로파일 한정
- 신규 API 는 `anyRequest().authenticated()` 로 JWT 인증 필요 (GET `/api/ipo/home`, `/api/ipo/search` 는 permitAll 유지)