### PR TITLE
feat: 청약이력 기반 평균 수익률 요약 API 추가

### DIFF
--- a/src/main/java/com/gong/modu/controller/SubscriptionHistoryController.java
+++ b/src/main/java/com/gong/modu/controller/SubscriptionHistoryController.java
@@ -51,6 +51,30 @@ public class SubscriptionHistoryController {
         return ResponseEntity.ok(historyService.getMyHistories(userId, status));
     }
 
+    @Operation(
+            summary = "청약이력 기반 평균 수익률 요약 (기능명세서 3.3)",
+            description = """
+                    매도 완료(COMPLETED) 청약이력을 매도일 기준 월별 그룹핑해 평균 수익률을 반환합니다.
+
+                    응답 구성:
+                    - monthlyReturnRates: 매도 이력이 있는 월만 포함, 매도일 오름차순. 꺾은선 그래프 데이터로 사용.
+                    - currentMonthReturnRate / lastMonthReturnRate: 이번달·저번달 평균. 막대 비교 그래프 데이터로 사용.
+                    - trend: INCREASED/DECREASED/UNCHANGED/NO_DATA. 프론트가 이 값으로 안내 메시지 분기.
+
+                    수익률 계산: ((sellPrice - offerPrice) × allocatedQuantity - fee - tax) / (offerPrice × allocatedQuantity) × 100
+                    필수 값(sellPrice/offerPrice/allocatedQuantity) 중 하나라도 없으면 해당 이력은 계산에서 제외됩니다.
+
+                    months 파라미터: 1~24 범위, 기본 6. 범위 밖이면 400 응답.
+                    """
+    )
+    @GetMapping("/return-rate")
+    public ResponseEntity<ReturnRateSummaryResponse> getReturnRateSummary(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(defaultValue = "6") int months
+    ) {
+        return ResponseEntity.ok(historyService.getReturnRateSummary(userId, months));
+    }
+
     @Operation(summary = "청약 이력 단건 조회")
     @GetMapping("/{historyId}")
     public ResponseEntity<SubscriptionHistoryResponse> getHistory(

--- a/src/main/java/com/gong/modu/domain/dto/user/CompletedHistoryCreateRequest.java
+++ b/src/main/java/com/gong/modu/domain/dto/user/CompletedHistoryCreateRequest.java
@@ -40,6 +40,11 @@ public class CompletedHistoryCreateRequest {
     @PositiveOrZero
     private Long allocatedQuantity;
 
+    @Schema(description = "공모가(1주당). 수익률 계산의 기준값이므로 반드시 입력 권장. 누락 시 수익률 계산에서 제외됨",
+            example = "20000")
+    @PositiveOrZero
+    private BigDecimal offerPrice;
+
     @Schema(description = "매도 단가", example = "50000")
     @PositiveOrZero
     private BigDecimal sellPrice;

--- a/src/main/java/com/gong/modu/domain/dto/user/ReturnRateSummaryResponse.java
+++ b/src/main/java/com/gong/modu/domain/dto/user/ReturnRateSummaryResponse.java
@@ -1,0 +1,59 @@
+package com.gong.modu.domain.dto.user;
+
+import com.gong.modu.domain.enums.ipo.ReturnRateTrend;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+// 청약이력 기반 평균 수익률 요약 응답 DTO (기능명세서 3.3)
+// 월별 평균 수익률 + 이번달/저번달 비교 트렌드를 반환
+@Getter
+@Builder
+@Schema(description = "청약이력 기반 평균 수익률 요약 (기능명세서 3.3). 월별 꺾은선 + 이번달/저번달 비교 데이터 제공")
+public class ReturnRateSummaryResponse {
+
+    @Schema(description = "조회 기간 (개월). 요청한 months 값", example = "6")
+    private int months;
+
+    @Schema(description = "월별 평균 수익률 목록. 매도 완료 이력이 있는 월만 포함, 매도일(sellDate) 기준 오름차순")
+    private List<MonthlyReturnRate> monthlyReturnRates;
+
+    @Schema(description = "이번달 평균 수익률 (%). 이번달에 매도 완료 이력이 없으면 null", example = "31.00")
+    private BigDecimal currentMonthReturnRate;
+
+    @Schema(description = "저번달 평균 수익률 (%). 저번달에 매도 완료 이력이 없으면 null", example = "20.00")
+    private BigDecimal lastMonthReturnRate;
+
+    @Schema(description = """
+                    이번달 평균 수익률 vs 저번달 평균 수익률 비교 결과. 프론트는 이 값으로 안내 메시지를 분기합니다.
+
+                    - INCREASED: 이번달 평균 수익률이 저번달보다 높음 (예: "저번달에 비해 이번달 평균 수익률이 증가했어요!")
+                    - DECREASED: 이번달 평균 수익률이 저번달보다 낮음 (예: "저번달에 비해 이번달 평균 수익률이 감소했어요!")
+                    - UNCHANGED: 이번달 평균 수익률이 저번달과 동일 (예: "저번달과 이번달 평균 수익률이 같아요")
+                    - NO_DATA: 이번달 또는 저번달에 매도 완료 이력이 없어 비교 불가 (currentMonthReturnRate 또는 lastMonthReturnRate 중 하나 이상이 null인 경우)
+                    """,
+            example = "INCREASED",
+            allowableValues = {"INCREASED", "DECREASED", "UNCHANGED", "NO_DATA"})
+    private ReturnRateTrend trend;
+
+    @Getter
+    @Builder
+    @Schema(description = "월별 평균 수익률 단건")
+    public static class MonthlyReturnRate {
+
+        @Schema(description = "연도", example = "2026")
+        private int year;
+
+        @Schema(description = "월 (1~12)", example = "5")
+        private int month;
+
+        @Schema(description = "해당 월의 평균 수익률 (%). 소수점 둘째자리까지", example = "31.00")
+        private BigDecimal averageReturnRate;
+
+        @Schema(description = "평균 계산에 포함된 매도 완료 이력 건수 (필수 값 누락 이력은 제외)", example = "3")
+        private int recordCount;
+    }
+}

--- a/src/main/java/com/gong/modu/domain/enums/ipo/ReturnRateTrend.java
+++ b/src/main/java/com/gong/modu/domain/enums/ipo/ReturnRateTrend.java
@@ -1,0 +1,18 @@
+package com.gong.modu.domain.enums.ipo;
+
+// 이번달 평균 수익률 vs 저번달 평균 수익률 비교 결과를 표현하는 Enum
+// 백엔드는 enum만 내려주고 프론트가 메시지("저번달에 비해 이번달 평균 수익률이 증가했어요!" 등) 처리
+public enum ReturnRateTrend {
+
+    // 이번달 평균 수익률이 저번달보다 높음
+    INCREASED,
+
+    // 이번달 평균 수익률이 저번달보다 낮음
+    DECREASED,
+
+    // 이번달 평균 수익률이 저번달과 동일
+    UNCHANGED,
+
+    // 이번달 또는 저번달에 매도 완료 이력이 없어 비교 불가
+    NO_DATA
+}

--- a/src/main/java/com/gong/modu/repository/user/UserSubscriptionHistoryRepository.java
+++ b/src/main/java/com/gong/modu/repository/user/UserSubscriptionHistoryRepository.java
@@ -5,6 +5,7 @@ import com.gong.modu.domain.entity.user.User;
 import com.gong.modu.domain.entity.user.UserSubscriptionHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 // 사용자 청약 이력 조회 Repository
@@ -19,6 +20,14 @@ public interface UserSubscriptionHistoryRepository extends JpaRepository<UserSub
     List<UserSubscriptionHistory> findByUserAndRecordStatus(
             User user,
             SubscriptionRecordStatus recordStatus
+    );
+
+    // 특정 사용자의 특정 상태 + 매도일이 from 이상인 청약 이력 조회
+    // 평균 수익률 계산(3.3 기능)에서 최근 N개월 범위로 좁힐 때 사용
+    List<UserSubscriptionHistory> findByUserAndRecordStatusAndSellDateGreaterThanEqual(
+            User user,
+            SubscriptionRecordStatus recordStatus,
+            LocalDate from
     );
 
     // 특정 공모 이벤트에 연결된 사용자 청약 이력 조회

--- a/src/main/java/com/gong/modu/service/user/ReturnRateCalculator.java
+++ b/src/main/java/com/gong/modu/service/user/ReturnRateCalculator.java
@@ -1,0 +1,128 @@
+package com.gong.modu.service.user;
+
+import com.gong.modu.domain.dto.user.ReturnRateSummaryResponse;
+import com.gong.modu.domain.entity.user.UserSubscriptionHistory;
+import com.gong.modu.domain.enums.ipo.ReturnRateTrend;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+// 청약이력 기반 평균 수익률 계산 컴포넌트 (기능명세서 3.3)
+// 한 건당 수익률: ((sellPrice - offerPrice) * allocatedQuantity - fee - tax) / (offerPrice * allocatedQuantity) * 100
+// 월별 평균: 매도일(sellDate) 기준 월별 그룹핑 후 단순 평균
+@Component
+public class ReturnRateCalculator {
+
+    // 백분율 계산 시 사용하는 스케일 (소수점 둘째자리)
+    private static final int PERCENTAGE_SCALE = 2;
+
+    // 한 건의 청약이력으로부터 수익률(%)을 계산하는 메서드
+    // 필수 값(sellPrice/offerPrice/allocatedQuantity) 누락이거나 0이면 null 반환
+    public BigDecimal calculateReturnRate(UserSubscriptionHistory history) {
+        BigDecimal offerPrice = history.getOfferPrice();
+        BigDecimal sellPrice = history.getSellPrice();
+        Long allocated = history.getAllocatedQuantity();
+
+        if (offerPrice == null || sellPrice == null || allocated == null || allocated <= 0) {
+            return null;
+        }
+        if (offerPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            return null;
+        }
+
+        BigDecimal quantity = BigDecimal.valueOf(allocated);
+        BigDecimal subscriptionAmount = offerPrice.multiply(quantity);
+        BigDecimal sellAmount = sellPrice.multiply(quantity);
+
+        BigDecimal fee = history.getFee() != null ? history.getFee() : BigDecimal.ZERO;
+        BigDecimal tax = history.getTax() != null ? history.getTax() : BigDecimal.ZERO;
+
+        BigDecimal profit = sellAmount.subtract(subscriptionAmount).subtract(fee).subtract(tax);
+
+        return profit
+                .multiply(BigDecimal.valueOf(100))
+                .divide(subscriptionAmount, PERCENTAGE_SCALE, RoundingMode.HALF_UP);
+    }
+
+    // COMPLETED 이력 리스트 + 요청 기간을 받아 응답 DTO를 만드는 메서드
+    // 매도일 기준 그룹핑 → 월별 평균 산출 → 이번달/저번달 비교 트렌드 판정
+    public ReturnRateSummaryResponse summarize(
+            List<UserSubscriptionHistory> completedHistories,
+            int months,
+            LocalDate today
+    ) {
+        // 1) 매도일 기준 YearMonth 별로 수익률 누적 (필수값 누락 이력은 자동 제외)
+        Map<YearMonth, List<BigDecimal>> ratesByMonth = new LinkedHashMap<>();
+        for (UserSubscriptionHistory h : completedHistories) {
+            LocalDate sellDate = h.getSellDate();
+            if (sellDate == null) continue;
+
+            BigDecimal rate = calculateReturnRate(h);
+            if (rate == null) continue;
+
+            YearMonth ym = YearMonth.from(sellDate);
+            ratesByMonth.computeIfAbsent(ym, k -> new ArrayList<>()).add(rate);
+        }
+
+        // 2) 월 기준 오름차순으로 정렬한 응답 리스트 구성
+        List<ReturnRateSummaryResponse.MonthlyReturnRate> monthly = ratesByMonth.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> {
+                    YearMonth ym = entry.getKey();
+                    List<BigDecimal> rates = entry.getValue();
+                    return ReturnRateSummaryResponse.MonthlyReturnRate.builder()
+                            .year(ym.getYear())
+                            .month(ym.getMonthValue())
+                            .averageReturnRate(average(rates))
+                            .recordCount(rates.size())
+                            .build();
+                })
+                .toList();
+
+        // 3) 이번달/저번달 평균 + 트렌드 판정
+        YearMonth currentYm = YearMonth.from(today);
+        YearMonth lastYm = currentYm.minusMonths(1);
+
+        BigDecimal currentMonthAvg = ratesByMonth.containsKey(currentYm)
+                ? average(ratesByMonth.get(currentYm))
+                : null;
+        BigDecimal lastMonthAvg = ratesByMonth.containsKey(lastYm)
+                ? average(ratesByMonth.get(lastYm))
+                : null;
+
+        ReturnRateTrend trend = resolveTrend(currentMonthAvg, lastMonthAvg);
+
+        return ReturnRateSummaryResponse.builder()
+                .months(months)
+                .monthlyReturnRates(monthly)
+                .currentMonthReturnRate(currentMonthAvg)
+                .lastMonthReturnRate(lastMonthAvg)
+                .trend(trend)
+                .build();
+    }
+
+    // 수익률 리스트의 단순 평균을 계산하는 메서드 (스케일 2, HALF_UP)
+    private BigDecimal average(List<BigDecimal> rates) {
+        BigDecimal sum = rates.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+        return sum.divide(BigDecimal.valueOf(rates.size()), PERCENTAGE_SCALE, RoundingMode.HALF_UP);
+    }
+
+    // 이번달/저번달 평균을 비교해 트렌드 enum을 결정하는 메서드
+    private ReturnRateTrend resolveTrend(BigDecimal currentAvg, BigDecimal lastAvg) {
+        if (currentAvg == null || lastAvg == null) {
+            return ReturnRateTrend.NO_DATA;
+        }
+        int cmp = currentAvg.compareTo(lastAvg);
+        if (cmp > 0) return ReturnRateTrend.INCREASED;
+        if (cmp < 0) return ReturnRateTrend.DECREASED;
+        return ReturnRateTrend.UNCHANGED;
+    }
+}

--- a/src/main/java/com/gong/modu/service/user/SubscriptionHistoryService.java
+++ b/src/main/java/com/gong/modu/service/user/SubscriptionHistoryService.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 // 청약 이력 (4.1 과거 투자 이력 + 4.2 현재 청약 중 이력) 관리 서비스
@@ -21,9 +23,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SubscriptionHistoryService {
 
+    // 평균 수익률 그래프 기간 파라미터의 허용 범위 (1~24개월)
+    private static final int MIN_MONTHS = 1;
+    private static final int MAX_MONTHS = 24;
+
     private final UserRepository userRepository;
     private final IpoEventRepository ipoEventRepository;
     private final UserSubscriptionHistoryRepository historyRepository;
+    private final ReturnRateCalculator returnRateCalculator;
 
     // 4.1 과거 투자 이력 생성 (DB 종목 조회 없이 사용자 직접 입력, status = COMPLETED)
     @Transactional
@@ -38,6 +45,7 @@ public class SubscriptionHistoryService {
                 .securityCompany(request.getSecurityCompany())
                 .subscribedQuantity(request.getSubscribedQuantity())
                 .allocatedQuantity(request.getAllocatedQuantity())
+                .offerPrice(request.getOfferPrice())
                 .sellPrice(request.getSellPrice())
                 .fee(request.getFee())
                 .tax(request.getTax())
@@ -82,6 +90,32 @@ public class SubscriptionHistoryService {
         return histories.stream()
                 .map(SubscriptionHistoryResponse::from)
                 .toList();
+    }
+
+    // 청약이력 기반 평균 수익률 요약 조회 (기능명세서 3.3)
+    // 최근 months 개월의 COMPLETED 이력을 매도일 기준 월별 그룹핑 → 평균 수익률 + 이번달/저번달 트렌드 반환
+    @Transactional(readOnly = true)
+    public ReturnRateSummaryResponse getReturnRateSummary(Long userId, int months) {
+        if (months < MIN_MONTHS || months > MAX_MONTHS) {
+            throw new CustomException(ErrorCode.SUBSCRIPTION_HISTORY_INVALID_INPUT);
+        }
+
+        User user = getUser(userId);
+
+        LocalDate today = LocalDate.now();
+        // months - 1 인 이유: 이번달 포함해서 총 months 개월이 되도록
+        // 예: months=6, today=2026-05-24 → from = 2025-12-01 (12월~5월 = 6개월)
+        YearMonth fromYearMonth = YearMonth.from(today).minusMonths(months - 1L);
+        LocalDate fromDate = fromYearMonth.atDay(1);
+
+        List<UserSubscriptionHistory> histories = historyRepository
+                .findByUserAndRecordStatusAndSellDateGreaterThanEqual(
+                        user,
+                        SubscriptionRecordStatus.COMPLETED,
+                        fromDate
+                );
+
+        return returnRateCalculator.summarize(histories, months, today);
     }
 
     // 단건 조회


### PR DESCRIPTION
## #️⃣연관된 이슈

#46 

## 📝작업 내용

- 기능명세서 3.3 청약이력 기반 평균 수익률 API 추가
- 매도 완료 이력을 매도일 기준 월별 그룹핑 → 평균 수익률 + 이번달/저번달 비교
- 명세 4.1.1 누락 필드(offerPrice) 보완 — 수익률 계산 기준값


## 스크린샷 (선택)

<img width="561" height="419" alt="스크린샷 2026-05-24 20 05 51" src="https://github.com/user-attachments/assets/4f69c2f9-1046-428e-bc8c-6fa33b0998d5" />


## 신규 API
GET /api/subscription-history/return-rate?months=

응답 예시:
~~~json
{
  "months": 6,
  "monthlyReturnRates": [
    { "year": 2026, "month": 3, "averageReturnRate": 69.64, "recordCount": 1 },
    { "year": 2026, "month": 5, "averageReturnRate": 11.06, "recordCount": 1 }
  ],
  "currentMonthReturnRate": 11.06,
  "lastMonthReturnRate": null,
  "trend": "NO_DATA"
}
~~~

## 핵심 변경
| 파일 | 역할 |
|------|------|
| domain/enums/ipo/ReturnRateTrend.java (신규) | INCREASED / DECREASED / UNCHANGED / NO_DATA |
| domain/dto/user/ReturnRateSummaryResponse.java (신규) | 월별 배열 + 이번달/저번달 + trend |
| service/user/ReturnRateCalculator.java (신규) | 단건 수익률 계산 + 월별 그룹핑 + 트렌드 판정 |
| repository/user/UserSubscriptionHistoryRepository.java | findByUserAndRecordStatusAndSellDateGreaterThanEqual 추가 |
| service/user/SubscriptionHistoryService.java | getReturnRateSummary(userId, months) + offerPrice 매핑 보완 |
| controller/SubscriptionHistoryController.java | GET /return-rate + Swagger 한국어 설명 |
| domain/dto/user/CompletedHistoryCreateRequest.java | offerPrice 필드 추가 |

## 수익률 계산 규칙
한 건당:
~~~
청약금액 = offerPrice × allocatedQuantity
매도금액 = sellPrice  × allocatedQuantity
손익     = 매도금액 - 청약금액 - (fee ?? 0) - (tax ?? 0)
수익률(%) = 손익 / 청약금액 × 100   (scale 2, HALF_UP)
~~~
- offerPrice / sellPrice / allocatedQuantity 중 하나라도 null·0 이면 해당 이력은 계산 제외 (recordCount 에도 미포함)
- 월별 평균은 그 월의 유효 수익률들의 단순 평균
- BigDecimal scale·반올림은 기존 IpoSignalCalculator 컨벤션(HALF_UP, scale 2) 준수

## 트렌드 판정 (enum)
이번달(YearMonth.now()) 평균 vs 저번달(minusMonths(1)) 평균:
- 둘 다 있고 이번달 > 저번달 → INCREASED
- 둘 다 있고 이번달 < 저번달 → DECREASED
- 둘 다 있고 동일 → UNCHANGED
- 한쪽이라도 데이터 없음 → NO_DATA

메시지 문자열은 프론트에서 i18n / 분기 처리 (Swagger description에 메시지 예시 명시).

## 엣지 케이스
| 케이스 | 응답 |
|--------|------|
| COMPLETED 이력 0건 | monthlyReturnRates: [], current/last null, trend NO_DATA |
| 기간 내 매도 이력 있으나 이번달·저번달 데이터 없음 | 그래프만 채워지고 trend NO_DATA |
| 필수값 누락 이력 | 계산 제외 (recordCount 미포함) |
| months ≤ 0 또는 > 24 | 400 SUBSCRIPTION_HISTORY_INVALID_INPUT |
| 토큰 없음 | 401 |

