### PR TITLE
fix(dart): TLSv1.2 강제 설정으로 DART API SSL handshake_failure 회피

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,9 @@ services:
       DART_API_KEY: ${DART_API_KEY}
       KIS_APP_KEY: ${KIS_APP_KEY}
       KIS_APP_SECRET: ${KIS_APP_SECRET}
+      # JVM heap 상한 + DART API (opendart.fss.or.kr) 가 TLSv1.3 ClientHello 를 거부해
+      # SSLHandshakeException(handshake_failure) 가 발생하는 문제 회피용으로 TLSv1.2 강제
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -Djdk.tls.client.protocols=TLSv1.2"
 
     ports:
       - "8080:8080"


### PR DESCRIPTION
DART(opendart.fss.or.kr) 서버가 Java 17 의 기본 TLSv1.3 ClientHello 를 fatal alert(handshake_failure) 로 거부하는 현상 확인. JAVA_TOOL_OPTIONS 에 -Djdk.tls.client.protocols=TLSv1.2 추가해 협상 성공하도록 강제.

EC2 호스트의 curl(openssl) 은 정상 작동했으나 컨테이너 내 Netty JDK SSL stack 에서만 실패했던 패턴. 새벽 1시 스케줄러 및 admin sync 모두 동일 원인.
