### PR TITLE
fix(dart): netty-tcnative + namedGroups 로 DART SSL handshake_failure 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	//runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.115.Final:osx-aarch64'
 
+	// Netty 가 JDK SSL stack 대신 BoringSSL(OpenSSL 계열) 사용하도록 native lib 제공
+	// DART(opendart.fss.or.kr) 같은 한국 정부 API 가 Java 17 기본 cipher/namedGroups 를
+	// 거부해서 SSLHandshakeException(handshake_failure) 가 발생하는 문제 해결.
+	// Netty 가 classpath 에서 자동 감지해 SSL provider 로 BoringSSL 우선 사용.
+	runtimeOnly 'io.netty:netty-tcnative-boringssl-static:2.0.66.Final'
+
 	// Email
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,9 +81,13 @@ services:
       DART_API_KEY: ${DART_API_KEY}
       KIS_APP_KEY: ${KIS_APP_KEY}
       KIS_APP_SECRET: ${KIS_APP_SECRET}
-      # JVM heap 상한 + DART API (opendart.fss.or.kr) 가 TLSv1.3 ClientHello 를 거부해
-      # SSLHandshakeException(handshake_failure) 가 발생하는 문제 회피용으로 TLSv1.2 강제
-      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -Djdk.tls.client.protocols=TLSv1.2"
+      # JVM heap 상한 + DART API (opendart.fss.or.kr) SSL handshake_failure 회피
+      # - TLSv1.2 강제: 일부 한국 정부 API 가 TLSv1.3 ClientHello 거부
+      # - namedGroups 제한: Java 17 의 신규 EC curves(x25519/x448/ffdhe*) 일부를 DART 가 거부 →
+      #   보편적인 secp256r1/secp384r1/secp521r1 만 사용하도록 제한
+      # (실제로는 build.gradle 의 netty-tcnative-boringssl-static 이 우선 사용되어
+      #  Netty 가 BoringSSL 로 협상하지만, JDK SSL 로 fallback 되는 경로 대비)
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -Djdk.tls.client.protocols=TLSv1.2 -Djdk.tls.namedGroups=secp256r1,secp384r1,secp521r1"
 
     ports:
       - "8080:8080"


### PR DESCRIPTION
TLSv1.2 강제만으로는 SSL handshake_failure 가 해결 안 됨.
원인 좁힘: Java 17 의 기본 EC curves(x25519/x448/ffdhe*) 또는 cipher 일부를 DART 서버가 거부.

1. netty-tcnative-boringssl-static 의존성 추가
   - Netty 가 JDK SSL 대신 BoringSSL(OpenSSL 계열) 자동 detect/사용
   - EC2 호스트의 curl(openssl) 이 정상 작동했던 것과 동일한 cipher set 사용 가능

2. JAVA_TOOL_OPTIONS 에 -Djdk.tls.namedGroups 추가
   - BoringSSL 로딩 실패 시 JDK SSL fallback 경로 대비
   - 보편적인 secp256r1/secp384r1/secp521r1 만 사용