### PR TITLE
fix(dart): WebClient 에 명시적 SslContext 적용해 SSL handshake_failure 해결

### DIFF
--- a/src/main/java/com/gong/modu/config/WebClientConfig.java
+++ b/src/main/java/com/gong/modu/config/WebClientConfig.java
@@ -1,9 +1,16 @@
 package com.gong.modu.config;
 
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import javax.net.ssl.SSLException;
+import java.util.List;
 
 // 외부 HTTP API 호출에 사용할 WebClient Bean들을 등록하는 설정 클래스
 @Configuration
@@ -12,6 +19,21 @@ public class WebClientConfig {
     // DART 공시 원문 ZIP은 투자설명서 등 큰 문서가 수 MB에 달하므로 메모리 버퍼 한도를 넉넉히 설정
     private static final int DART_MAX_IN_MEMORY_SIZE = 64 * 1024 * 1024;
 
+    // DART 서버가 받는 보편적인 TLSv1.2 cipher 목록 (OpenSSL/curl 기본 cipher 와 동일)
+    // Java 17 기본 cipher set 일부를 DART 가 거부해 handshake_failure 가 발생하므로 명시 강제.
+    private static final List<String> DART_TLS_CIPHERS = List.of(
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_RSA_WITH_AES_256_GCM_SHA384"
+    );
+
     @Value("${external.dart.base-url}")
     private String dartBaseUrl;
 
@@ -19,9 +41,22 @@ public class WebClientConfig {
     private String kisBaseUrl;
 
     @Bean
-    public WebClient dartWebClient() {
+    public WebClient dartWebClient() throws SSLException {
+        // DART(opendart.fss.or.kr) 가 Java 17 기본 cipher/protocol 일부를 거부해
+        // SSLHandshakeException(handshake_failure) 가 발생하는 문제 해결:
+        // - TLSv1.2 만 사용
+        // - OpenSSL/curl 과 동일한 보편 cipher list 강제
+        SslContext sslContext = SslContextBuilder.forClient()
+                .protocols("TLSv1.2")
+                .ciphers(DART_TLS_CIPHERS)
+                .build();
+
+        HttpClient httpClient = HttpClient.create()
+                .secure(sslSpec -> sslSpec.sslContext(sslContext));
+
         return WebClient.builder()
                 .baseUrl(dartBaseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .codecs(configurer -> configurer.defaultCodecs()
                         .maxInMemorySize(DART_MAX_IN_MEMORY_SIZE))
                 .build();


### PR DESCRIPTION
JVM 옵션(-Djdk.tls.client.protocols=TLSv1.2 -Djdk.tls.namedGroups=...) 및 netty-tcnative-boringssl-static 의존성 추가만으로는 Netty 가 여전히 JDK SSL stack 사용해 handshake_failure 지속.

WebClient 내부의 Netty HttpClient 에 명시적 SslContext 부여:
- protocols("TLSv1.2") 강제
- ciphers() 로 OpenSSL/curl 기본 cipher 10개 강제

이 방법은 자동 detect 우회 없이 Netty 가 반드시 이 SslContext 사용하므로 JVM 옵션이 무시되던 문제 해결.
