### PR TITLE
fix(dart): disabledAlgorithms 완화로 DART RSA cipher 협상 가능하게

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,12 +82,11 @@ services:
       KIS_APP_KEY: ${KIS_APP_KEY}
       KIS_APP_SECRET: ${KIS_APP_SECRET}
       # JVM heap 상한 + DART API (opendart.fss.or.kr) SSL handshake_failure 회피
-      # - TLSv1.2 강제: 일부 한국 정부 API 가 TLSv1.3 ClientHello 거부
-      # - namedGroups 제한: Java 17 의 신규 EC curves(x25519/x448/ffdhe*) 일부를 DART 가 거부 →
-      #   보편적인 secp256r1/secp384r1/secp521r1 만 사용하도록 제한
-      # (실제로는 build.gradle 의 netty-tcnative-boringssl-static 이 우선 사용되어
-      #  Netty 가 BoringSSL 로 협상하지만, JDK SSL 로 fallback 되는 경로 대비)
-      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -Djdk.tls.client.protocols=TLSv1.2 -Djdk.tls.namedGroups=secp256r1,secp384r1,secp521r1"
+      # 진단 결과: DART 는 TLS_RSA_WITH_AES_128_GCM_SHA256 (RSA-only cipher) 만 받는데
+      # Java 17 이 보안상 RSA-only cipher 를 기본 disabledAlgorithms 에 포함시켜
+      # 협상 단계에서 제외 → 매치 cipher 없음 → handshake_failure 발생.
+      # 해결: disabledAlgorithms 에서 RSA 관련 제거. TLSv1/v1.1 같은 진짜 위험한 것만 유지.
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -Djdk.tls.client.protocols=TLSv1.2 -Djdk.tls.namedGroups=secp256r1,secp384r1,secp521r1 -Djdk.tls.disabledAlgorithms=SSLv3,TLSv1,TLSv1.1,RC4,DES,MD5withRSA,DH keySize < 1024,EC keySize < 224,3DES_EDE_CBC,anon,NULL"
 
     ports:
       - "8080:8080"

--- a/src/main/java/com/gong/modu/config/WebClientConfig.java
+++ b/src/main/java/com/gong/modu/config/WebClientConfig.java
@@ -10,7 +10,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 
 import javax.net.ssl.SSLException;
-import java.util.List;
 
 // 외부 HTTP API 호출에 사용할 WebClient Bean들을 등록하는 설정 클래스
 @Configuration
@@ -18,21 +17,6 @@ public class WebClientConfig {
 
     // DART 공시 원문 ZIP은 투자설명서 등 큰 문서가 수 MB에 달하므로 메모리 버퍼 한도를 넉넉히 설정
     private static final int DART_MAX_IN_MEMORY_SIZE = 64 * 1024 * 1024;
-
-    // DART 서버가 받는 보편적인 TLSv1.2 cipher 목록 (OpenSSL/curl 기본 cipher 와 동일)
-    // Java 17 기본 cipher set 일부를 DART 가 거부해 handshake_failure 가 발생하므로 명시 강제.
-    private static final List<String> DART_TLS_CIPHERS = List.of(
-            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
-            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
-            "TLS_RSA_WITH_AES_128_GCM_SHA256",
-            "TLS_RSA_WITH_AES_256_GCM_SHA384"
-    );
 
     @Value("${external.dart.base-url}")
     private String dartBaseUrl;
@@ -42,13 +26,12 @@ public class WebClientConfig {
 
     @Bean
     public WebClient dartWebClient() throws SSLException {
-        // DART(opendart.fss.or.kr) 가 Java 17 기본 cipher/protocol 일부를 거부해
-        // SSLHandshakeException(handshake_failure) 가 발생하는 문제 해결:
-        // - TLSv1.2 만 사용
-        // - OpenSSL/curl 과 동일한 보편 cipher list 강제
+        // DART(opendart.fss.or.kr) 는 TLSv1.2 + RSA-only cipher(AES128-GCM-SHA256) 만 받음.
+        // Java 17 기본 cipher set 이 신규 cipher 우선이라 협상 실패하므로 TLSv1.2 만 강제하고
+        // cipher 선택은 JVM 옵션의 disabledAlgorithms 완화로 RSA cipher 가 협상에 포함되도록 함.
+        // (JAVA_TOOL_OPTIONS 에서 disabledAlgorithms 조정함 - docker-compose.yml 참고)
         SslContext sslContext = SslContextBuilder.forClient()
                 .protocols("TLSv1.2")
-                .ciphers(DART_TLS_CIPHERS)
                 .build();
 
         HttpClient httpClient = HttpClient.create()


### PR DESCRIPTION
진단으로 DART (opendart.fss.or.kr) 가 TLS_RSA_WITH_AES_128_GCM_SHA256 만 받는다는 점 확인 (EC2 호스트 openssl s_client 결과 AES128-GCM-SHA256).

JDK 17 의 기본 jdk.tls.disabledAlgorithms 가 RSA-only cipher (forward secrecy 없음) 를 비활성화해서, 그동안 cipher 명시·protocol 강제·
netty-tcnative 추가 모두 무효였음. 협상 후보에서 자체적으로 잘려나갔기 때문.

해결:
- JAVA_TOOL_OPTIONS 의 disabledAlgorithms 를 명시적으로 좁혀 RSA cipher 활성화 (TLSv1/v1.1/SSLv3/RC4/DES 등 진짜 위험한 것만 유지)
- WebClientConfig 의 cipher 명시는 제거 (JVM 옵션과 일관성)