### PR TITLE
fix(dart): Security.setProperty 로 disabledAlgorithms 설정 (JVM 옵션 공백 문제…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,11 +82,11 @@ services:
       KIS_APP_KEY: ${KIS_APP_KEY}
       KIS_APP_SECRET: ${KIS_APP_SECRET}
       # JVM heap 상한 + DART API (opendart.fss.or.kr) SSL handshake_failure 회피
-      # 진단 결과: DART 는 TLS_RSA_WITH_AES_128_GCM_SHA256 (RSA-only cipher) 만 받는데
-      # Java 17 이 보안상 RSA-only cipher 를 기본 disabledAlgorithms 에 포함시켜
-      # 협상 단계에서 제외 → 매치 cipher 없음 → handshake_failure 발생.
-      # 해결: disabledAlgorithms 에서 RSA 관련 제거. TLSv1/v1.1 같은 진짜 위험한 것만 유지.
-      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -Djdk.tls.client.protocols=TLSv1.2 -Djdk.tls.namedGroups=secp256r1,secp384r1,secp521r1 -Djdk.tls.disabledAlgorithms=SSLv3,TLSv1,TLSv1.1,RC4,DES,MD5withRSA,DH keySize < 1024,EC keySize < 224,3DES_EDE_CBC,anon,NULL"
+      # - TLSv1.2 강제 (DART 가 TLSv1.3 ClientHello 거부)
+      # - namedGroups 제한 (Java 17 신규 EC curves 제외)
+      # - disabledAlgorithms 변경은 JAVA_TOOL_OPTIONS 로 전달 불가(값에 공백 포함됨)
+      #   → ModuApplication.main() 에서 Security.setProperty() 로 직접 설정
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -Djdk.tls.client.protocols=TLSv1.2 -Djdk.tls.namedGroups=secp256r1,secp384r1,secp521r1"
 
     ports:
       - "8080:8080"

--- a/src/main/java/com/gong/modu/ModuApplication.java
+++ b/src/main/java/com/gong/modu/ModuApplication.java
@@ -4,11 +4,24 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.security.Security;
+
 @EnableJpaAuditing
 @SpringBootApplication
 public class ModuApplication {
 
 	public static void main(String[] args) {
+		// Java 17 기본 jdk.tls.disabledAlgorithms 가 RSA-only cipher 와 일부 keySize 제한을
+		// 포함해 DART(opendart.fss.or.kr) 같은 RSA-only TLS 서버와 협상 실패(handshake_failure)
+		// 발생. JAVA_TOOL_OPTIONS 로는 값 안에 공백(예: "DH keySize < 1024")이 있어 전달 불가하므로
+		// 앱 시작 시점에 Security.setProperty 로 직접 설정한다.
+		// (TLSv1/v1.1/SSLv3, RC4, DES, MD5withRSA, 3DES, NULL, anon 같은 진짜 위험 항목만 남기고
+		//  keySize 제한, jdk.disabled.namedCurves 등은 제거 → RSA cipher 협상 가능)
+		Security.setProperty(
+				"jdk.tls.disabledAlgorithms",
+				"SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, 3DES_EDE_CBC, anon, NULL"
+		);
+
 		SpringApplication.run(ModuApplication.class, args);
 	}
 


### PR DESCRIPTION
… 회피)

JAVA_TOOL_OPTIONS 환경변수는 공백으로 옵션을 split 하므로 값 안에 공백이 들어가는 -Djdk.tls.disabledAlgorithms=...DH keySize < 1024... 가 'keySize' 를 별도 JVM 옵션으로 인식해 부팅 실패 (Unrecognized option: keySize).

해결: 앱 main() 첫 줄에서 Security.setProperty 로 직접 설정. SpringApplication.run 호출 전에 적용되므로 모든 SSL 연산에 영향. JAVA_TOOL_OPTIONS 에서는 공백 옵션 제거.