### PR TITLE
[FIX] spac 기업 처리

### DIFF
--- a/src/main/java/com/gong/modu/domain/entity/ipo/Company.java
+++ b/src/main/java/com/gong/modu/domain/entity/ipo/Company.java
@@ -59,6 +59,14 @@ public class Company extends BaseTimeEntity {
     @Column(name = "established_at") // 설립일은 API에서 없거나 파싱되지 않을 수 있어 NULL 허용
     private LocalDate establishedAt; // 회사 설립일
 
+    @Column(name = "is_spac", nullable = false)
+    @Builder.Default
+    private boolean isSpac = false;
+
+    public boolean isSpac() {
+        return isSpac;
+    }
+
     // DART/KRX/KIS 수집 결과로 기업 기본정보를 갱신하는 메서드
     public void updateBasicInfo(
                                  String corpName, // 새 기업명
@@ -68,7 +76,8 @@ public class Company extends BaseTimeEntity {
                                  String stockName, // 새 종목명
                                  MarketType marketType, // 새 시장구분
                                  String industryCode, // 새 업종 코드
-                                 LocalDate establishedAt // 새 설립일
+                                 LocalDate establishedAt, // 새 설립일
+                                 boolean isSpac // 스팩 여부
     ) {
         this.corpName = corpName;
         this.corpNameEng = corpNameEng;
@@ -78,5 +87,13 @@ public class Company extends BaseTimeEntity {
         this.marketType = marketType;
         this.industryCode = industryCode;
         this.establishedAt = establishedAt;
+        this.isSpac = isSpac;
+    }
+
+    public static boolean detectSpac(String corpName) {
+        if (corpName == null) return false;
+        return corpName.contains("스팩")
+                || corpName.contains("기업인수목적")
+                || corpName.toUpperCase().contains("SPAC");
     }
 }

--- a/src/main/java/com/gong/modu/service/ipo/IpoDisclosureReportQueryService.java
+++ b/src/main/java/com/gong/modu/service/ipo/IpoDisclosureReportQueryService.java
@@ -35,8 +35,7 @@ public class IpoDisclosureReportQueryService {
         IpoDisclosureReport report = reports.get(0);
         IpoEvent ipoEvent = report.getIpoEvent();
         Company company = ipoEvent.getCompany();
-        boolean isSpac = company.getCorpName().contains("스팩")
-                || company.getCorpName().toUpperCase().contains("SPAC");
+        boolean isSpac = company.isSpac();
 
         if (report.getCompanySummary() == null) {
             return IpoDisclosureReportResponse.builder()

--- a/src/main/java/com/gong/modu/service/ipo/IpoDisclosureReportSummarizeService.java
+++ b/src/main/java/com/gong/modu/service/ipo/IpoDisclosureReportSummarizeService.java
@@ -43,8 +43,7 @@ public class IpoDisclosureReportSummarizeService {
         IpoOffering offering = ipoEvent.getOffering();
         IpoMetric metric = ipoEvent.getMetric();
 
-        boolean isSpac = company.getCorpName().contains("스팩")
-                || company.getCorpName().toUpperCase().contains("SPAC");
+        boolean isSpac = company.isSpac();
 
         List<IpoEventBroker> brokers = eventBrokerRepository.findByIpoEventId(ipoEvent.getId());
         List<CompanyFinancialHighlight> financials = financialHighlightRepository

--- a/src/main/java/com/gong/modu/service/ipo/IpoHomeQueryService.java
+++ b/src/main/java/com/gong/modu/service/ipo/IpoHomeQueryService.java
@@ -146,8 +146,7 @@ public class IpoHomeQueryService {
             return null;
         }
 
-        String corpName = event.getCompany().getCorpName();
-        if (corpName != null && (corpName.contains("기업인수목적") || corpName.contains("스팩"))) {
+        if (event.getCompany().isSpac()) {
             return SignalUnavailableReason.SPAC;
         }
 

--- a/src/main/java/com/gong/modu/service/pipeline/DartCompanySyncService.java
+++ b/src/main/java/com/gong/modu/service/pipeline/DartCompanySyncService.java
@@ -39,6 +39,8 @@ public class DartCompanySyncService {
         String stockCode = emptyToNull(response.getStockCode());
         String stockName = emptyToNull(response.getStockName());
 
+        boolean isSpac = Company.detectSpac(response.getCorpName());
+
         return companyRepository.findByCorpCode(response.getCorpCode())
                 .map(existing -> {
                     existing.updateBasicInfo( // 기존 Company 기본 정보를 최신 DART 응답값으로 갱신
@@ -49,7 +51,8 @@ public class DartCompanySyncService {
                             stockName,
                             marketType,
                             response.getIndutyCode(),
-                            establishedAt
+                            establishedAt,
+                            isSpac
                     );
 
                     return existing; // 갱신된 기존 엔티티 반환
@@ -64,6 +67,7 @@ public class DartCompanySyncService {
                                 .marketType(marketType)
                                 .industryCode(response.getIndutyCode())
                                 .establishedAt(establishedAt)
+                                .isSpac(isSpac)
                                 .build()
                 ));
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

isSpac 필드가 스팩기업임에도 false로 반환되는 버그를 발견하여 수정했습니다.
1. 스팩 판정 키워드가 파일마다 다름
- disclosure/summarize: "스팩", "SPAC" 만 체크 → "기업인수목적" 누락
- financials/home: "기업인수목적", "스팩" 만 체크 → "SPAC" 영문 누락

2. 스팩 판정 로직이 4개 파일에 중복됨 (키워드 추가 시 모든 파일을 수정해야 하는 구조)

## 변경 내용 
Company 엔티티
- `is_spac` DB 컬럼 추가
- `isSpac()` 메서드를 런타임 텍스트 분석 → DB 필드 반환으로 변경
- `updateBasicInfo()`에 `isSpac` 파라미터 추가
- `detectSpac(String corpName)` static 메서드 추가 (판정 로직을 한 곳에서 관리)

DartCompanySyncService
- 기업 수집 시 `Company.detectSpac()`으로 계산 후 `is_spac` 저장
- 이후 새로 수집되는 기업은 자동으로 올바른 값이 저장됨

서비스 레이어 
- `IpoDisclosureReportQueryService`, `IpoDisclosureReportSummarizeService`, `IpoHomeQueryService` 모두 인라인 텍스트 비교 → `company.isSpac()` 통일

### 스크린샷 (선택)
<img width="560" height="103" alt="스크린샷 2026-05-31 오후 4 00 00" src="https://github.com/user-attachments/assets/f3696038-0967-4046-8857-8f56d1907012" />

<img width="569" height="218" alt="스크린샷 2026-05-31 오후 4 01 21" src="https://github.com/user-attachments/assets/7f88b685-098c-44ce-be38-575cf1d6243c" />


## 💬리뷰 요구사항(선택)
