### PR TITLE
[FEAT] complete API 에 배정수량 옵션 + 응답에 찜 여부 추가

### DIFF
--- a/src/main/java/com/gong/modu/controller/SubscriptionHistoryController.java
+++ b/src/main/java/com/gong/modu/controller/SubscriptionHistoryController.java
@@ -42,7 +42,14 @@ public class SubscriptionHistoryController {
         return ResponseEntity.ok(Map.of("id", id));
     }
 
-    @Operation(summary = "내 청약 이력 조회 (status 미지정 시 전체)")
+    @Operation(
+            summary = "내 청약 이력 조회 (status 미지정 시 전체)",
+            description = """
+                    각 항목의 `favorited` 필드는 연결된 공모주가 사용자의 관심 등록 목록에 있는지 여부.
+                    `ipoEventId` 가 null 인 4.1 직접 입력 이력은 항상 false.
+                    IpoHomeItemResponse / IpoDetailResponse 의 favorited 필드와 동일 시맨틱.
+                    """
+    )
     @GetMapping
     public ResponseEntity<List<SubscriptionHistoryResponse>> getMyHistories(
             @AuthenticationPrincipal Long userId,
@@ -75,7 +82,10 @@ public class SubscriptionHistoryController {
         return ResponseEntity.ok(historyService.getReturnRateSummary(userId, months));
     }
 
-    @Operation(summary = "청약 이력 단건 조회")
+    @Operation(
+            summary = "청약 이력 단건 조회",
+            description = "응답의 `favorited` 필드는 연결된 공모주 찜 여부. `ipoEventId` 가 null 인 직접 입력 이력은 항상 false."
+    )
     @GetMapping("/{historyId}")
     public ResponseEntity<SubscriptionHistoryResponse> getHistory(
             @AuthenticationPrincipal Long userId,
@@ -95,7 +105,14 @@ public class SubscriptionHistoryController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "ONGOING 이력을 매도 정보 입력으로 COMPLETED 전환")
+    @Operation(
+            summary = "ONGOING 이력을 매도 정보 입력으로 COMPLETED 전환",
+            description = """
+                    매도 단가/수수료/세금/매도일을 받아 COMPLETED 로 상태 전환.
+                    옵션 필드 `allocatedQuantity` 를 함께 전달하면 매도 정보와 동시에 배정수량도 업데이트.
+                    이미 PATCH `/api/subscription-history/{historyId}` 로 입력했거나 별도 흐름으로 처리한 경우 생략.
+                    """
+    )
     @PostMapping("/{historyId}/complete")
     public ResponseEntity<Void> completeHistory(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/gong/modu/domain/dto/user/CompleteHistoryRequest.java
+++ b/src/main/java/com/gong/modu/domain/dto/user/CompleteHistoryRequest.java
@@ -33,4 +33,12 @@ public class CompleteHistoryRequest {
     @Schema(description = "매도일 (필수)", example = "2026-06-20", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull
     private LocalDate sellDate;
+
+    // 옵션 필드. 매도 화면에서 배정수량을 함께 입력하는 흐름 지원용.
+    // null 이면 기존값 유지 (PATCH 로 이미 입력한 케이스), 값이 있으면 함께 업데이트.
+    @Schema(description = "실제 배정받은 주식 수 (옵션). 매도 화면에서 함께 입력받기 위한 필드. " +
+            "null 이면 기존 값을 유지하고, 값이 들어오면 함께 업데이트합니다.",
+            example = "10")
+    @PositiveOrZero
+    private Long allocatedQuantity;
 }

--- a/src/main/java/com/gong/modu/domain/dto/user/SubscriptionHistoryResponse.java
+++ b/src/main/java/com/gong/modu/domain/dto/user/SubscriptionHistoryResponse.java
@@ -76,7 +76,14 @@ public class SubscriptionHistoryResponse {
     @Schema(description = "이력 마지막 수정 시각", example = "2026-05-24T10:00:00")
     private LocalDateTime updatedAt;
 
-    public static SubscriptionHistoryResponse from(UserSubscriptionHistory history) {
+    @Schema(description = "연결된 공모주 찜 여부. ipoEventId 가 null 인 직접 입력 이력은 항상 false. " +
+            "IpoHomeItemResponse / IpoDetailResponse 의 favorited 필드와 동일 시맨틱.",
+            example = "true")
+    private boolean favorited;
+
+    // favorited 는 Service 에서 InterestIpoService 를 통해 별도 계산한 뒤 주입.
+    // IpoEvent 가 null 인 4.1 직접 입력 이력은 호출 측에서 false 를 전달.
+    public static SubscriptionHistoryResponse from(UserSubscriptionHistory history, boolean favorited) {
         return SubscriptionHistoryResponse.builder()
                 .id(history.getId())
                 .recordStatus(history.getRecordStatus())
@@ -98,6 +105,7 @@ public class SubscriptionHistoryResponse {
                 .memo(history.getMemo())
                 .createdAt(history.getCreatedAt())
                 .updatedAt(history.getUpdatedAt())
+                .favorited(favorited)
                 .build();
     }
 }

--- a/src/main/java/com/gong/modu/service/user/SubscriptionHistoryService.java
+++ b/src/main/java/com/gong/modu/service/user/SubscriptionHistoryService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Set;
 
 // 청약 이력 (4.1 과거 투자 이력 + 4.2 현재 청약 중 이력) 관리 서비스
 @Service
@@ -31,6 +32,7 @@ public class SubscriptionHistoryService {
     private final IpoEventRepository ipoEventRepository;
     private final UserSubscriptionHistoryRepository historyRepository;
     private final ReturnRateCalculator returnRateCalculator;
+    private final InterestIpoService interestIpoService;
 
     // 4.1 과거 투자 이력 생성 (DB 종목 조회 없이 사용자 직접 입력, status = COMPLETED)
     @Transactional
@@ -87,8 +89,15 @@ public class SubscriptionHistoryService {
                 ? historyRepository.findByUserOrderByCreatedAtDesc(user)
                 : historyRepository.findByUserAndRecordStatus(user, status);
 
+        // 사용자의 관심 IpoEvent ID 를 한 번에 Set 으로 조회 → 각 항목에서 contains 로 boolean 변환 (N+1 회피)
+        Set<Long> favoritedIpoEventIds = interestIpoService.getInterestedIpoEventIds(userId);
+
         return histories.stream()
-                .map(SubscriptionHistoryResponse::from)
+                .map(h -> {
+                    boolean favorited = h.getIpoEvent() != null
+                            && favoritedIpoEventIds.contains(h.getIpoEvent().getId());
+                    return SubscriptionHistoryResponse.from(h, favorited);
+                })
                 .toList();
     }
 
@@ -122,7 +131,12 @@ public class SubscriptionHistoryService {
     @Transactional(readOnly = true)
     public SubscriptionHistoryResponse getHistory(Long userId, Long historyId) {
         UserSubscriptionHistory history = findOwnedHistory(userId, historyId);
-        return SubscriptionHistoryResponse.from(history);
+
+        // 단건이라 existsByUserAndIpoEventId 단일 쿼리로 충분 (IpoDetailQueryService 와 동일 패턴)
+        Long ipoEventId = history.getIpoEvent() == null ? null : history.getIpoEvent().getId();
+        boolean favorited = ipoEventId != null && interestIpoService.isInterested(userId, ipoEventId);
+
+        return SubscriptionHistoryResponse.from(history, favorited);
     }
 
     // 청약 이력 수정 (null인 필드는 기존 값 유지)
@@ -147,9 +161,16 @@ public class SubscriptionHistoryService {
     }
 
     // ONGOING 이력에 매도 정보를 입력해 COMPLETED 로 전환
+    // allocatedQuantity 옵션이 함께 전달되면 매도 정보 반영 전에 배정수량도 업데이트.
+    // 도메인 라이프사이클 분리(updateAllocationResult vs completeRecord) 는 유지하고,
+    // 매도 화면에서 한 번에 입력하는 프론트 UX 를 지원하기 위한 보강.
     @Transactional
     public void completeHistory(Long userId, Long historyId, CompleteHistoryRequest request) {
         UserSubscriptionHistory history = findOwnedHistory(userId, historyId);
+
+        if (request.getAllocatedQuantity() != null) {
+            history.updateAllocationResult(request.getAllocatedQuantity());
+        }
 
         history.completeRecord(
                 request.getSellPrice(),


### PR DESCRIPTION
### 배경

POST /api/subscription-history/{historyId}/complete 요청에 allocatedQuantity(배정수량) 추가. 매도 화면에서 매도 정보와 함께 배정수량을 한 번에 입력하는 흐름이 필요.
GET /api/subscription-history 응답에 찜 여부 필드 추가. 청약이력 목록에서 찜 아이콘 표시 용도.

### 변경 내용
CompleteHistoryRequest - allocatedQuantity 옵션 필드(nullable, @PositiveOrZero)
SubscriptionHistoryService.completeHistory - 옵션 값이 들어오면 updateAllocationResult 함께 호출
SubscriptionHistoryResponse - favorited 필드 + from(history, favorited) 시그니처
SubscriptionHistoryService.getMyHistories - InterestIpoService.getInterestedIpoEventIds 로 한 번에 Set 조회 → 각 항목 Set.contains 로 boolean 변환 (N+1 회피)
SubscriptionHistoryService.getHistory -InterestIpoService.isInterested 단일 쿼리
SubscriptionHistoryController - 영향받은 엔드포인트의 @Operation.description 한 줄씩 보강

### 재사용한 기존 코드 
InterestIpoService.getInterestedIpoEventIds(userId) - IpoHomeQueryService 와 동일 패턴
InterestIpoService.isInterested(userId, ipoEventId) - IpoDetailQueryService 와 동일 패턴
UserSubscriptionHistory.updateAllocationResult / completeRecord - 도메인 메서드 그대로